### PR TITLE
Small usability improvements; fixes #766, #799, #790

### DIFF
--- a/CDP4SiteDirectory.Tests/TeamComposition/TeamCompositionBrowserViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/TeamComposition/TeamCompositionBrowserViewModelTestFixture.cs
@@ -124,7 +124,7 @@ namespace CDP4SiteDirectory.Tests
         public void VerifyThatPropertiesAreSet()
         {
             var vm = new TeamCompositionBrowserViewModel(this.engineeringModelSetup, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, this.dialogNavigationService.Object, null);
-            Assert.AreEqual("Team composition, test model", vm.Caption);
+            Assert.AreEqual("Team Composition, test model", vm.Caption);
             Assert.AreEqual(1, vm.Participants.Count);
 
             var row = vm.Participants.Single();

--- a/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
@@ -87,15 +87,13 @@ namespace CDP4SiteDirectory.ViewModels
         public PersonDialogViewModel(Person person, ThingTransaction transaction, ISession session, bool isRoot, ThingDialogKind dialogKind, IThingDialogNavigationService thingDialogNavigationService, Thing container, IEnumerable<Thing> chainOfContainers = null)
             : base(person, transaction, session, isRoot, dialogKind, thingDialogNavigationService, container, chainOfContainers)
         {
-            this.Password = string.Empty;
-
             this.WhenAnyValue(vm => vm.PwdEditIsChecked).Subscribe(x =>
             {
                 this.RaisePropertyChanged("Password");
                 this.RaisePropertyChanged("PasswordConfirmation");
             });
         }
-        
+
         /// <summary>
         /// Gets or sets the password confirmation value
         /// </summary>
@@ -113,7 +111,7 @@ namespace CDP4SiteDirectory.ViewModels
             get { return this.pwdEditIsChecked; }
             set { this.RaiseAndSetIfChanged(ref this.pwdEditIsChecked, value); }
         }
-        
+
         /// <summary>
         /// Gets or sets the ShortName
         /// </summary>
@@ -133,7 +131,7 @@ namespace CDP4SiteDirectory.ViewModels
         /// Gets the <see cref="ICommand"/> to set the default <see cref="EmailAddress"/>
         /// </summary>
         public ReactiveCommand<object> SetDefaultEmailAddressCommand { get; private set; } 
-        
+
         /// <summary>
         /// Gets the error message for the property with the given name.
         /// </summary>
@@ -154,7 +152,7 @@ namespace CDP4SiteDirectory.ViewModels
                     {
                         this.ValidationErrors.Remove(validationErrorToRemove);
                     }
-                    
+
                     return null;
                 }
 
@@ -175,7 +173,7 @@ namespace CDP4SiteDirectory.ViewModels
                     {
                         this.ValidationErrors.Add(rule);
                     }
-                    
+
                     return rule.ErrorText;
                 }
 
@@ -185,7 +183,7 @@ namespace CDP4SiteDirectory.ViewModels
                 {
                     this.ValidationErrors.Remove(validationError);
                 }
-                
+
                 return ValidationService.ValidateProperty(columnName, this);
             }
         }
@@ -203,6 +201,21 @@ namespace CDP4SiteDirectory.ViewModels
             this.SetDefaultEmailAddressCommand =
                 ReactiveCommand.Create(this.WhenAnyValue(x => x.SelectedEmailAddress).Select(x => x != null && !this.IsReadOnly));
             this.SetDefaultEmailAddressCommand.Subscribe(_ => this.ExecuteSetDefaultEmailAddressCommand());
+        }
+
+        /// <summary>
+        /// Update the properties
+        /// </summary>
+        protected override void UpdateProperties()
+        {
+            base.UpdateProperties();
+
+            if (this.dialogKind == ThingDialogKind.Create)
+            {
+                this.IsActive = true;
+            }
+
+            this.Password = string.Empty;
         }
 
         /// <summary>

--- a/CDP4SiteDirectory/ViewModels/TeamComposition/TeamCompositionBrowserViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/TeamComposition/TeamCompositionBrowserViewModel.cs
@@ -44,7 +44,7 @@ namespace CDP4SiteDirectory.ViewModels
         /// <summary>
         /// The Panel Caption
         /// </summary>
-        private const string PanelCaption = "Team composition";
+        private const string PanelCaption = "Team Composition";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamCompositionBrowserViewModel"/> class

--- a/CDP4SiteDirectory/Views/TeamComposition/TeamCompositionBrowser.xaml
+++ b/CDP4SiteDirectory/Views/TeamComposition/TeamCompositionBrowser.xaml
@@ -76,17 +76,20 @@
 
         <dxg:GridControl Grid.Row="2"
                          ItemsSource="{Binding Participants}"
+                         AutoExpandAllGroups="True"
                          SelectedItem="{Binding SelectedThing,
                                                 Mode=TwoWay,
                                                 UpdateSourceTrigger=PropertyChanged}">
 
             <dxg:GridControl.View>
                 <dxg:CardView x:Name="View"
+                              Loaded="View_OnLoaded"
                               AllowEditing="False"
-                              CardAlignment="Center"
+                              CardAlignment="Near"
+                              CardLayout="Columns"
                               CardHeaderBinding="{Binding Path=Data.Person,
                                                           RelativeSource={RelativeSource Self}}"
-                              CardMargin="15"
+                              CardMargin="5"
                               SeparatorThickness="0" />
 
             </dxg:GridControl.View>
@@ -102,7 +105,7 @@
                         </Style>
                     </dxg:GridColumn.CellStyle>
                 </dxg:GridColumn>
-                <dxg:GridColumn FieldName="DomainShortnames" Header="Domains" />
+                <dxg:GridColumn FieldName="DomainShortnames" Header="Domains" GroupIndex="0"/>
                 <dxg:GridColumn FieldName="TelephoneNumber" Header="Telephone Number" />
                 <dxg:GridColumn FieldName="EmailAddress" Header="Email Address">
                     <dxg:GridColumn.CellTemplate>

--- a/CDP4SiteDirectory/Views/TeamComposition/TeamCompositionBrowser.xaml.cs
+++ b/CDP4SiteDirectory/Views/TeamComposition/TeamCompositionBrowser.xaml.cs
@@ -6,6 +6,7 @@
 
 namespace CDP4SiteDirectory.Views
 {
+    using System.Windows;
     using System.Windows.Controls;
     using CDP4Composition;
     using CDP4Composition.Attributes;
@@ -38,6 +39,19 @@ namespace CDP4SiteDirectory.Views
             {
                 this.InitializeComponent();
             }
+        }
+
+        /// <summary>
+        /// Collapses the cards when the CardView is loaded.
+        /// </summary>
+        /// <remarks>
+        /// Seems to be overboard to create a whole MVVM behaviour for one line of code. Unfortunatelly, there is no XAML dependency property to set this.
+        /// </remarks>
+        /// <param name="sender">The sender</param>
+        /// <param name="e">The arguments.</param>
+        private void View_OnLoaded(object sender, RoutedEventArgs e)
+        {
+            this.View.CollapseAllCards();
         }
     }
 }

--- a/EngineeringModel/Views/Dialogs/EngineeringModelSetupDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/EngineeringModelSetupDialog.xaml
@@ -104,7 +104,7 @@
                     </lc:LayoutItem>
                 </lc:LayoutGroup>
 
-                <lc:LayoutGroup Header="Active Domain" Orientation="Vertical">
+                <lc:LayoutGroup Header="Active Domain" Orientation="Vertical" IsEnabled="{Binding IsActiveDomainSelectionReadOnly, Converter={StaticResource NotConverter}}">
                     <lc:LayoutItem>
                         <dxe:ListBoxEdit VerticalAlignment="Stretch"
                                          HorizontalAlignment="Stretch"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #790 - New Person dialog "Is Active" is true by default
Fixes #799 - Team Composition browser improvements: grouping by Domain and cards collapsed when opening.
Fixes #766 - Active Domains tab disabled entirely on creating a new EngineeringModelSetup

