### PR TITLE
Fixes #818 Deprecated Requirement remains visible

### DIFF
--- a/CDP4Composition/Views/CommonThingControl.xaml.cs
+++ b/CDP4Composition/Views/CommonThingControl.xaml.cs
@@ -51,6 +51,11 @@ namespace CDP4Composition.Views
         private static Logger logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
+        /// The declaration of the <see cref="DependencyProperty"/> that is accessible via the <see cref="FilteringMode"/> setter method.
+        /// </summary>
+        private static readonly DependencyProperty FilteringModeProperty = DependencyProperty.Register("FilteringMode", typeof(TreeListFilteringMode?), typeof(CommonThingControl));
+
+        /// <summary>
         /// The declaration of the <see cref="DependencyProperty"/> that is accessible via the <see cref="GridView"/> setter method.
         /// </summary>
         private static readonly DependencyProperty GridViewProperty = DependencyProperty.Register("GridView", typeof(DataViewBase), typeof(CommonThingControl), new PropertyMetadata(OnGridViewChanged));
@@ -73,6 +78,15 @@ namespace CDP4Composition.Views
         /// Gets the <see cref="IDialogNavigationService"/> used to navigate to a <see cref="IDialogViewModel"/>
         /// </summary>
         public IDialogNavigationService DialogNavigationService { get; private set; }
+
+        /// <summary>
+        /// The <see cref="FilteringMode"/> this <see cref="CommonThingControl"/> is associated with
+        /// </summary>
+        public TreeListFilteringMode? FilteringMode
+        {
+            get => this.GetValue(FilteringModeProperty) as TreeListFilteringMode?;
+            set => this.SetValue(FilteringModeProperty, value);
+        }
 
         /// <summary>
         /// The <see cref="GridView"/> this <see cref="CommonThingControl"/> is associated with
@@ -116,7 +130,10 @@ namespace CDP4Composition.Views
 
             if (commonThingControl.GridView is TreeListView treeListView)
             {
-                treeListView.SetValue(TreeListView.FilteringModeProperty, TreeListFilteringMode.EntireBranch);
+                treeListView.SetValue(
+                    TreeListView.FilteringModeProperty, 
+                    commonThingControl.FilteringMode ?? TreeListFilteringMode.EntireBranch);
+
                 treeListView.SetValue(TreeListView.EnableDynamicLoadingProperty, false);
             }
         }

--- a/Requirements/Views/RequirementsBrowser.xaml
+++ b/Requirements/Views/RequirementsBrowser.xaml
@@ -315,7 +315,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <views:CommonThingControl GridView="{Binding ElementName=View}" />
+            <views:CommonThingControl GridView="{Binding ElementName=View}" FilteringMode="ParentBranch" />
 
             <views:BrowserHeader Grid.Row="1" />
 
@@ -354,7 +354,6 @@
                                   ShowNodeImages="False"
                                   ShowVerticalLines="False"
                                   FixedLineWidth="0"
-                                  FilteringMode="ParentBranch"
                                   TreeDerivationMode="HierarchicalDataTemplate"
                                   TreeLineStyle="Solid"
                                   VerticalScrollbarVisibility="Auto"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Because of the fact that both RequirementSpecifications and Requirements are deprecatable, the normal filtering logic (TreeListFilteringMode.EntireBranch) doesn't work for an un-deprecated RequirementSpecification and a deprecated Requirement. 
This has been changed to TreeListFilteringMode.ParentBranch, but only for this situation, because of the fact that the Filter panel functionality works slightly different because of this.
