### PR TITLE
Formula field has same value as Computed value

### DIFF
--- a/CDP4Reporting/Utilities/ProcessedValueSetGenerator.cs
+++ b/CDP4Reporting/Utilities/ProcessedValueSetGenerator.cs
@@ -199,7 +199,7 @@ namespace CDP4Reporting.Utilities
                 processedValueSet = new ProcessedValueSet(parameterValueSet, validationResult);
             }
 
-            if (processedValueSet.IsDirty(componentIndex, parameterType, switchKind, parameterValueSet.Manual[componentIndex], computedValue, parameterValueSet.Reference[componentIndex], parameterValueSet.Formula[componentIndex], out var valueSetValues))
+            if (processedValueSet.IsDirty(componentIndex, parameterType, switchKind, parameterValueSet.Manual[componentIndex], computedValue, parameterValueSet.Reference[componentIndex], computedValue, out var valueSetValues))
             {
                 processedValueSet.UpdateClone(valueSetValues);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Formula field needs same value as Computed value in case in is written back to the EngineeringModel using a COMET Report.
Otherwise the value doesn't show correctly in the parameter sheet created in the Excel plugin.