### PR TITLE
Fixes #577 Open requirement specification browser

### DIFF
--- a/CDP4Reporting/ViewModels/ReportDesignerViewModel.cs
+++ b/CDP4Reporting/ViewModels/ReportDesignerViewModel.cs
@@ -877,10 +877,7 @@ namespace CDP4Reporting.ViewModels
                 }
             }
 
-            if (!(reportingParameters.Any()))
-            {
-                return;
-            }
+            var presenter = (notifyParameterChange ? this.currentReportDesignerDocument?.Preview : null) as DocumentPreviewControl;
 
             // Create new dynamic parameters
             foreach (var reportingParameter in reportingParameters)
@@ -891,6 +888,17 @@ namespace CDP4Reporting.ViewModels
                         : null;
 
                 this.CreateDynamicParameter(reportingParameter, previouslySetValue);
+
+                if (notifyParameterChange)
+                {
+                    var existingInvisibleParameter = 
+                        presenter?.ParametersModel.Parameters.SingleOrDefault(x => !x.Visible && x.Name == reportingParameter.ParameterName);
+
+                    if (existingInvisibleParameter != null)
+                    {
+                        existingInvisibleParameter.Value = reportingParameter.DefaultValue;
+                    }
+                }
             }
         }
 

--- a/Requirements/Views/RequirementsSpecificationEditor.xaml
+++ b/Requirements/Views/RequirementsSpecificationEditor.xaml
@@ -13,7 +13,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/CDP4Composition;component/Resources/CDP4Styles.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/CDP4Composition;component/CommonView/Resources/CDP4Styles.xaml"/>
             </ResourceDictionary.MergedDictionaries>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"></BooleanToVisibilityConverter>


### PR DESCRIPTION
[Fix] invisible report parameters value refresh on rebuild in report preview

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix opening requirement specification browser.
Small fix that allows report rebuild in preview to refresh parameter values that are not visible in the report previewer's parameter panel.