### PR TITLE
fixes #445 Rule Verification doesn't show any result after executing

### DIFF
--- a/CDP4Composition.Tests/RuleVerification/RuleVerificationServiceTestFixture.cs
+++ b/CDP4Composition.Tests/RuleVerification/RuleVerificationServiceTestFixture.cs
@@ -12,6 +12,7 @@ namespace CDP4Composition.Tests.RuleVerification
     using System.Linq;
     using System.Reactive.Concurrency;
     using System.Threading.Tasks;
+
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;

--- a/CDP4Composition.Tests/RuleVerification/RuleVerificationServiceTestFixture.cs
+++ b/CDP4Composition.Tests/RuleVerification/RuleVerificationServiceTestFixture.cs
@@ -10,7 +10,8 @@ namespace CDP4Composition.Tests.RuleVerification
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Reactive.Concurrency;    
+    using System.Reactive.Concurrency;
+    using System.Threading.Tasks;
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
@@ -18,6 +19,7 @@ namespace CDP4Composition.Tests.RuleVerification
     using CDP4Composition.Services;
     using CDP4Dal;
     using CDP4Dal.Events;
+    using CDP4Dal.Operations;
     using Moq;
     using NUnit.Framework;
     using ReactiveUI;
@@ -126,8 +128,8 @@ namespace CDP4Composition.Tests.RuleVerification
         {
             var ruleVerificationList = new RuleVerificationList(Guid.NewGuid(), this.cache, this.uri);
             var service = new RuleVerificationService(this.builtInRules);
-            
-            Assert.Throws<ArgumentNullException>(() => service.Execute(null, ruleVerificationList));
+
+            Assert.ThrowsAsync<ArgumentNullException>(() => service.Execute(null, ruleVerificationList));
         }
 
         [Test]
@@ -135,7 +137,7 @@ namespace CDP4Composition.Tests.RuleVerification
         {
             var service = new RuleVerificationService(this.builtInRules);
             
-            Assert.Throws<ArgumentNullException>(() => service.Execute(this.session.Object, null));
+            Assert.ThrowsAsync<ArgumentNullException>(() => service.Execute(this.session.Object, null));
         }
 
         [Test]
@@ -167,7 +169,7 @@ namespace CDP4Composition.Tests.RuleVerification
         }
 
         [Test]
-        public void VerifyThatUserRuleVerificationCanBeExecutedAndMessageBusMessagesAreReceived()
+        public async Task VerifyThatUserRuleVerificationCanBeExecutedAndMessageBusMessagesAreReceived()
         {
             var messageReceivedCounter = 0;
 
@@ -183,15 +185,21 @@ namespace CDP4Composition.Tests.RuleVerification
                                                Rule = binaryRelationshipRule
                                            };
 
+            this.session.Setup(s => s.Write(It.IsAny<OperationContainer>()))
+                        .Callback(() =>
+                        {
+                            CDPMessageBus.Current.SendObjectChangeEvent(userRuleVerification, EventKind.Updated);
+                        });
+
             ruleVerificationList.RuleVerification.Add(userRuleVerification);
 
             var listener = CDPMessageBus.Current.Listen<ObjectChangedEvent>(userRuleVerification)                
                 .Subscribe(
                 x => { messageReceivedCounter++; });
 
-            service.Execute(this.session.Object, ruleVerificationList);
+            await service.Execute(this.session.Object, ruleVerificationList);
 
-            Assert.AreEqual(2, messageReceivedCounter);
+            Assert.AreEqual(3, messageReceivedCounter);
         }
 
         [BuiltInRuleMetaDataExportAttribute("RHEA", "shortname", "verifies that the shortnames are correct")]

--- a/CDP4Composition/CommonView/AutoGenRows/RuleViolationRowViewModel.cs
+++ b/CDP4Composition/CommonView/AutoGenRows/RuleViolationRowViewModel.cs
@@ -9,17 +9,13 @@
 
 namespace CDP4CommonView
 {
-    using System;
-    using System.Reactive.Linq;
     using CDP4Common.CommonData;
-    using CDP4Common.DiagramData;
     using CDP4Common.EngineeringModelData;
-    using CDP4Common.ReportingData;
-    using CDP4Common.SiteDirectoryData;
     using CDP4Composition.Mvvm;
+
     using CDP4Dal;
     using CDP4Dal.Events;
-    using CDP4Dal.Permission;    
+
     using ReactiveUI;
 
     /// <summary>
@@ -27,6 +23,7 @@ namespace CDP4CommonView
     /// </summary>
     public partial class RuleViolationRowViewModel : RowViewModelBase<RuleViolation>
     {
+        private ObservableAsPropertyHelper<string> name;
 
         /// <summary>
         /// Backing field for <see cref="Description"/>
@@ -50,17 +47,13 @@ namespace CDP4CommonView
         public string Description
         {
             get { return this.description; }
-            set 
-            { 
-                this.RaiseAndSetIfChanged(ref this.description, value);
-                this.RaisePropertyChanged(nameof(Name));
-            }
+            set { this.RaiseAndSetIfChanged(ref this.description, value); }
         }
 
         /// <summary>
         /// Name property of the row
         /// </summary>
-        public string Name => this.description;
+        public string Name => this.name.Value;
 
         /// <summary>
         /// The event-handler that is invoked by the subscription that listens for updates
@@ -82,6 +75,16 @@ namespace CDP4CommonView
         {
             this.ModifiedOn = this.Thing.ModifiedOn;
             this.Description = this.Thing.Description;
+        }
+
+        protected override void InitializeSubscriptions()
+        {
+            base.InitializeSubscriptions();
+
+            this.name = this.WhenAnyValue(x => x.Description)
+                            .ToProperty(this, x => x.Name);
+
+            this.Disposables.Add(this.name);
         }
     }
 }

--- a/CDP4Composition/CommonView/AutoGenRows/RuleViolationRowViewModel.cs
+++ b/CDP4Composition/CommonView/AutoGenRows/RuleViolationRowViewModel.cs
@@ -44,17 +44,24 @@ namespace CDP4CommonView
             this.UpdateProperties();
         }
 
-
         /// <summary>
         /// Gets or sets the Description
         /// </summary>
         public string Description
         {
             get { return this.description; }
-            set { this.RaiseAndSetIfChanged(ref this.description, value); }
+            set 
+            { 
+                this.RaiseAndSetIfChanged(ref this.description, value);
+                this.RaisePropertyChanged(nameof(Name));
+            }
         }
 
-	
+        /// <summary>
+        /// Name property of the row
+        /// </summary>
+        public string Name => this.description;
+
         /// <summary>
         /// The event-handler that is invoked by the subscription that listens for updates
         /// on the <see cref="Thing"/> that is being represented by the view-model

--- a/CDP4Composition/Mvvm/BrowserViewModelBase.cs
+++ b/CDP4Composition/Mvvm/BrowserViewModelBase.cs
@@ -56,6 +56,7 @@ namespace CDP4Composition.Mvvm
     using NLog;
     
     using ReactiveUI;
+    using CDP4CommonView;
 
     /// <summary>
     /// The View-Model-base that shall be used by a view-model representing a Browser
@@ -851,12 +852,12 @@ namespace CDP4Composition.Mvvm
         public virtual void PopulateContextMenu()
         {
             this.ContextMenu.Clear();
-            if (this.SelectedThing == null)
+            if (this.SelectedThing is null or RuleViolationRowViewModel)
             {
                 return;
             }
 
-            if (!(this.SelectedThing is FolderRowViewModel))
+            if (this.SelectedThing is not FolderRowViewModel)
             {
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Edit", "CTRL+E", this.UpdateCommand, MenuItemKind.Edit));
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Inspect", "CTRL+I", this.InspectCommand, MenuItemKind.Inspect));
@@ -888,7 +889,7 @@ namespace CDP4Composition.Mvvm
                 }
             }
 
-            if (this.SelectedThing != null && this.SelectedThing.ContainedRows.Count > 0)
+            if (this.SelectedThing.ContainedRows.Count > 0)
             {
                 this.ContextMenu.Add(this.SelectedThing.IsExpanded ?
                     new ContextMenuItemViewModel("Collapse Rows", "", this.CollpaseRowsCommand, MenuItemKind.None, ClassKind.NotThing) :

--- a/CDP4Composition/Services/RuleVerification/IRuleVerificationService.cs
+++ b/CDP4Composition/Services/RuleVerification/IRuleVerificationService.cs
@@ -8,6 +8,7 @@ namespace CDP4Composition.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using CDP4Common.EngineeringModelData;
     using CDP4Dal;
 
@@ -41,6 +42,7 @@ namespace CDP4Composition.Services
         /// <param name="verificationList">
         /// The <see cref="RuleVerificationList"/> that needs to be verified.
         /// </param>
-        void Execute(ISession session, RuleVerificationList verificationList);
+        /// <returns>An awaitable <see cref="Task"/></returns>
+        Task Execute(ISession session, RuleVerificationList verificationList);
     }
 }

--- a/CDP4Composition/Services/RuleVerification/RuleVerificationService.cs
+++ b/CDP4Composition/Services/RuleVerification/RuleVerificationService.cs
@@ -1,6 +1,25 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RuleVerificationService.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -11,14 +30,16 @@ namespace CDP4Composition.Services
     using System.ComponentModel.Composition;
     using System.Reactive.Linq;
     using System.Threading.Tasks;
-    using CDP4Common;
+
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.Exceptions;
     using CDP4Common.SiteDirectoryData;
+
     using CDP4Dal;
     using CDP4Dal.Events;
     using CDP4Dal.Operations;
+
     using NLog;
     using ReactiveUI;
 
@@ -223,6 +244,8 @@ namespace CDP4Composition.Services
             }
 
             userRuleVerification.Violation.Clear();
+            userRuleVerification.Status = RuleVerificationStatusKind.PASSED;
+
             CDPMessageBus.Current.SendObjectChangeEvent(userRuleVerification, EventKind.Updated);
 
             IEnumerable<RuleViolation> violations = null;
@@ -251,7 +274,7 @@ namespace CDP4Composition.Services
                     break;
             }
 
-            if (violations != null)
+            if (violations is not null)
             {
                 userRuleVerification.Status = RuleVerificationStatusKind.FAILED;
 

--- a/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationListBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationListBrowserViewModel.cs
@@ -306,17 +306,18 @@ namespace CDP4EngineeringModel.ViewModels
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Execute the Rule Verification List", "", this.VerifyRuleVerificationList, MenuItemKind.None, ClassKind.NotThing));
             }
         }
-        
+
         /// <summary>
         /// Executes the <see cref="VerifyRuleVerificationList"/> <see cref="ReactiveCommand"/>
         /// </summary>
-        private void ExecuteVerifyRuleVerificationList()
+        /// <returns>An awaitable <see cref="Task"/></returns>
+        private async Task ExecuteVerifyRuleVerificationList()
         {
             var ruleVerificationList = this.SelectedThing as RuleVerificationListRowViewModel;
             if (ruleVerificationList != null)
             {
                 var ruleVerificationService = ServiceLocator.Current.GetInstance<IRuleVerificationService>();
-                ruleVerificationService.Execute(this.Session, ruleVerificationList.Thing);
+                await ruleVerificationService.Execute(this.Session, ruleVerificationList.Thing);
             }            
         }
 

--- a/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationRowViewModel.cs
+++ b/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationRowViewModel.cs
@@ -38,8 +38,13 @@ namespace CDP4EngineeringModel.ViewModels
             : base(ruleVerification, session, containerViewModel)
         {
             this.UpdateProperties();
+        }
 
-            //A subscription is made here in addition to the one made in the base class in order to be notified of non-persisntent changes which will not result in an updated revision number
+        protected override void InitializeSubscriptions()
+        {
+            base.InitializeSubscriptions();
+
+            //A subscription is made here in addition to the one made in the base class in order to be notified of non-persistent changes which will not result in an updated revision number
             var thingSubscription = CDPMessageBus.Current.Listen<ObjectChangedEvent>(this.Thing)
                 .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.RevisionNumber == RevisionNumber)
                 .ObserveOn(RxApp.MainThreadScheduler)

--- a/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationRowViewModel.cs
+++ b/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationRowViewModel.cs
@@ -13,6 +13,9 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Composition.Mvvm;
     using CDP4Dal;
     using CDP4Dal.Events;
+    using ReactiveUI;
+    using System.Reactive.Linq;
+    using System;
 
     /// <summary>
     /// A row representing a <see cref="RuleVerification"/>
@@ -35,6 +38,14 @@ namespace CDP4EngineeringModel.ViewModels
             : base(ruleVerification, session, containerViewModel)
         {
             this.UpdateProperties();
+
+            //A subscription is made here in addition to the one made in the base class in order to be notified of non-persisntent changes which will not result in an updated revision number
+            var thingSubscription = CDPMessageBus.Current.Listen<ObjectChangedEvent>(this.Thing)
+                .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.RevisionNumber == RevisionNumber)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(this.ObjectChangeEventHandler);
+
+            this.Disposables.Add(thingSubscription);
         }
 
         /// <summary>

--- a/EngineeringModel/Views/RuleVerificationListBrowser/RuleVerificationListBrowser.xaml
+++ b/EngineeringModel/Views/RuleVerificationListBrowser/RuleVerificationListBrowser.xaml
@@ -13,7 +13,7 @@
              xmlns:services="clr-namespace:CDP4Composition.Services;assembly=CDP4Composition"
              xmlns:viewModels="clr-namespace:CDP4EngineeringModel.ViewModels"
              xmlns:views="clr-namespace:CDP4Composition.Views;assembly=CDP4Composition"
-             xmlns:CDP4CommonView="clr-namespace:CDP4CommonView;assembly=CDP4Composition"
+             xmlns:cdp4CommonView="clr-namespace:CDP4CommonView;assembly=CDP4Composition"
              d:DesignHeight="300"
              d:DesignWidth="300"
              dx:ThemeManager.ThemeName="{Binding Path=ThemeName}"
@@ -67,7 +67,7 @@
             </dx:MeasurePixelSnapper>
         </HierarchicalDataTemplate>
 
-        <HierarchicalDataTemplate DataType="{x:Type CDP4CommonView:RuleViolationRowViewModel}">
+        <HierarchicalDataTemplate DataType="{x:Type cdp4CommonView:RuleViolationRowViewModel}">
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
@@ -80,7 +80,7 @@
                         </Image>
                     </dx:PixelSnapper>
                     <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding Description, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                                      Content="{Binding}"
                                       ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
                 </StackPanel>
             </dx:MeasurePixelSnapper>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Problem:
Violation rows were not being displayed against the validation rules when running the rule.
This was happening for the following reasons:

1) Violations are not persistent and don't update the revision number therefore updates were being ignored by the view model reactive query.

2) Violations were being overwritten when the rule was modified and written to the data store.

3) The view was not displaying the description text (just empty rows)

Solution:
Add the violations after the validation rule has been persisted. Listen for changes to the validation rule in the view model that do not have revision changes.

The solution looks a little convoluted because of the need to sequence the updates and listen to modifications.





