### PR TITLE
feat: #GH73 make DoE and participant shown as subnodes

### DIFF
--- a/CDP4Composition/Mvvm/BrowserViewModelBase.cs
+++ b/CDP4Composition/Mvvm/BrowserViewModelBase.cs
@@ -1,8 +1,8 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BrowserViewModelBase.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smieckowski, Ahmed Abulwafa Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Simon Wood
 //
 //    This file is part of CDP4-IME Community Edition.
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
@@ -19,9 +19,9 @@
 //    GNU Affero General Public License for more details.
 //
 //    You should have received a copy of the GNU Affero General Public License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//    along with this program. If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4Composition.Mvvm
 {
@@ -905,20 +905,25 @@ namespace CDP4Composition.Mvvm
 
             if (this.SelectedThing is not FolderRowViewModel)
             {
-                this.ContextMenu.Add(new ContextMenuItemViewModel("Edit", "CTRL+E", this.UpdateCommand, MenuItemKind.Edit));
+                if (this.SelectedThing.CanEditThing)
+                {
+                    this.ContextMenu.Add(new ContextMenuItemViewModel("Edit", "CTRL+E", this.UpdateCommand, MenuItemKind.Edit));
+                }
+
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Inspect", "CTRL+I", this.InspectCommand, MenuItemKind.Inspect));
 
-                var deprecableThing = this.SelectedThing.Thing as IDeprecatableThing;
-
-                if (deprecableThing == null)
-                {
-                    this.ContextMenu.Add(new ContextMenuItemViewModel(string.Format("Delete this {0}", this.camelCaseToSpaceConverter.Convert(this.SelectedThing.Thing.ClassKind, null, null, null)), "", this.DeleteCommand, MenuItemKind.Delete));
+                if (this.SelectedThing.CanEditThing)
+                { 
+                    if (this.SelectedThing.Thing is IDeprecatableThing deprecableThing)
+                    {
+                        this.ContextMenu.Add(new ContextMenuItemViewModel(deprecableThing.IsDeprecated ? "Un-Deprecate" : "Deprecate", "", this.DeprecateCommand, MenuItemKind.Deprecate));
+                    }
+                    else
+                    {
+                        this.ContextMenu.Add(new ContextMenuItemViewModel(string.Format("Delete this {0}", this.camelCaseToSpaceConverter.Convert(this.SelectedThing.Thing.ClassKind, null, null, null)), "", this.DeleteCommand, MenuItemKind.Delete));
+                    }
                 }
-                else
-                {
-                    this.ContextMenu.Add(new ContextMenuItemViewModel(deprecableThing.IsDeprecated ? "Un-Deprecate" : "Deprecate", "", this.DeprecateCommand, MenuItemKind.Deprecate));
-                }
-
+               
                 var categorizableThing = this.SelectedThing.Thing as ICategorizableThing;
 
                 if (categorizableThing != null && categorizableThing.Category.Any())

--- a/CDP4Composition/Mvvm/IRowViewModelBase.cs
+++ b/CDP4Composition/Mvvm/IRowViewModelBase.cs
@@ -1,11 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IRowViewModelBase.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Merlin Bieze, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru
-//            Nathanael Smiechowski, Kamil Wojnowski
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Simon Wood
 //
-//    This file is part of CDP4-IME Community Edition. 
+//    This file is part of CDP4-IME Community Edition.
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
@@ -20,7 +19,7 @@
 //    GNU Affero General Public License for more details.
 //
 //    You should have received a copy of the GNU Affero General Public License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//    along with this program. If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -116,5 +115,10 @@ namespace CDP4Composition.Mvvm
         /// Collapases the current row and all contained rows along the containment hierarchy
         /// </summary>
         void CollapseAllRows();
+
+        /// <summary>
+        /// Indicates if edit functions in context menu are active
+        /// </summary>
+        public bool CanEditThing { get; }
     }
 }

--- a/CDP4Composition/Mvvm/RowViewModelBase.cs
+++ b/CDP4Composition/Mvvm/RowViewModelBase.cs
@@ -249,6 +249,11 @@ namespace CDP4Composition.Mvvm
         }
 
         /// <summary>
+        /// Indicates if edit functions in context menu are active
+        /// </summary>
+        public virtual bool CanEditThing { get; } = true;
+
+        /// <summary>
         /// Gets the list of <see cref="IDisposable"/> objects that are referenced by this class used for cancelation of highlight.
         /// </summary>
         protected List<IDisposable> HighlightCancelDisposables { get; private set; }

--- a/CDP4SiteDirectory.Tests/ModelBrowser/ModelBrowserViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/ModelBrowser/ModelBrowserViewModelTestFixture.cs
@@ -1,8 +1,8 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ModelBrowserViewModelTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Simon Wood
 //
 //    This file is part of CDP4-IME Community Edition.
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
@@ -19,9 +19,9 @@
 //    GNU Affero General Public License for more details.
 //
 //    You should have received a copy of the GNU Affero General Public License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//    along with this program. If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4SiteDirectory.Tests
 {
@@ -170,8 +170,9 @@ namespace CDP4SiteDirectory.Tests
             viewmodel.SelectedThing = participantFolderRow.ContainedRows.First();
             var participantRow = participantFolderRow.ContainedRows.First() as ModelParticipantRowViewModel;
             Assert.NotNull(participantRow);
-            Assert.AreEqual("DoE: Thermal, Organization: RHEA", participantRow.Description);
+            Assert.AreEqual("Organization: RHEA", participantRow.Description);
             Assert.IsTrue(selectedThingChangedRaised);
+            Assert.That(participantRow.ContainedRows.Single().Thing, Is.EqualTo(testDomain));
         }
 
         [Test]
@@ -181,14 +182,15 @@ namespace CDP4SiteDirectory.Tests
 
             var model = new EngineeringModelSetup(Guid.NewGuid(), null, this.uri);
 
+            var domain = new DomainOfExpertise();
+            model.ActiveDomain.Add(domain);
+
             var participant = new Participant(Guid.NewGuid(), null, this.uri);
             participant.Person = new Person(Guid.NewGuid(), null, this.uri) { GivenName = "blabla", Surname = "blabla" };
+            participant.Domain.Add(domain);
 
             model.Participant.Add(participant);
             model.IterationSetup.Add(new IterationSetup());
-
-            var domain = new DomainOfExpertise();
-            model.ActiveDomain.Add(domain);
 
             this.siteDirectory.Model.Add(model);
             revPropertyInfo.SetValue(this.siteDirectory, 50);
@@ -203,6 +205,7 @@ namespace CDP4SiteDirectory.Tests
             Assert.AreEqual(1, participantFolderRow.ContainedRows.Count);
             Assert.AreEqual(1, iterationFolderRow.ContainedRows.Count);
             Assert.AreEqual(1, domainFolderRow.ContainedRows.Count);
+            Assert.AreEqual(1, domainFolderRow.ContainedRows[0].ContainedRows.Count);
 
             model.Participant.Clear();
             model.IterationSetup.Clear();

--- a/CDP4SiteDirectory.Tests/ModelBrowser/Rows/DomainOfExpertiseRowViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/ModelBrowser/Rows/DomainOfExpertiseRowViewModelTestFixture.cs
@@ -1,0 +1,95 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DomainOfExpertiseRowViewModelTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Simon Wood
+//
+//    This file is part of CDP4-IME Community Edition.
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4SiteDirectory.Tests.ModelBrowser.Rows
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+
+    using CDP4SiteDirectory.ViewModels.ModelBrowser.Rows;
+
+    using Moq;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DomainOfExpertiseRowViewModelTestFixture
+    {
+        [Test]
+        public void VerifyParticipantsAreInitialized()
+        {
+            Mock<ISession> session = new Mock<ISession>();
+            var thing = new DomainOfExpertise();
+
+            var viewModel = new DomainOfExpertiseRowViewModel(thing, session.Object, null);
+
+            var initialParticipants = new[]
+            {
+                new Participant() { Domain = new List<DomainOfExpertise> { thing } },
+                new Participant() { Domain = new List<DomainOfExpertise> { thing } },
+            };
+
+            viewModel.UpdateParticipants(initialParticipants);
+
+            CollectionAssert.AreEquivalent(viewModel.ContainedRows.Select(r => r.Thing), initialParticipants);
+        }
+
+        [Test]
+        public void VerifyParticipantsAreUpdated()
+        {
+            Mock<ISession> session = new Mock<ISession>();
+            var expertise = new DomainOfExpertise();
+            var otherExpertise = new DomainOfExpertise();
+
+            var viewModel = new DomainOfExpertiseRowViewModel(expertise, session.Object, null);
+
+            var participants = new[]
+            {
+                new Participant() { Domain = new List<DomainOfExpertise> { expertise } },
+                new Participant() { Domain = new List<DomainOfExpertise> { expertise } },
+                new Participant() { Domain = new List<DomainOfExpertise> { expertise } },
+                new Participant() { Domain = new List<DomainOfExpertise> { expertise } },
+                new Participant() { Domain = new List<DomainOfExpertise> { expertise } },
+            };
+
+            var participantWithOtherExpertise = new Participant() { Domain = new List<DomainOfExpertise> { otherExpertise } };
+
+            //Add top 3
+            viewModel.UpdateParticipants(participants.Take(3));
+
+            //Add all with first replaced by non-matching expertise
+            var participantsUpdate = participants.ToList();
+            participantsUpdate[0] = participantWithOtherExpertise;
+
+            viewModel.UpdateParticipants(participantsUpdate);
+
+            //Should contain all but the first.
+            CollectionAssert.AreEquivalent(viewModel.ContainedRows.Select(r => r.Thing), participants.Skip(1));
+        }
+    }
+}

--- a/CDP4SiteDirectory/ViewModels/ModelBrowser/Rows/DomainOfExpertiseRowViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/ModelBrowser/Rows/DomainOfExpertiseRowViewModel.cs
@@ -1,0 +1,86 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DomainOfExpertiseRowViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Simon Wood
+//
+//    This file is part of CDP4-IME Community Edition.
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4SiteDirectory.ViewModels.ModelBrowser.Rows
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Mvvm;
+
+    using CDP4Dal;
+
+    /// <summary>
+    /// Row class representing a <see cref="DomainOfExpertise"/>
+    /// </summary>
+    public class DomainOfExpertiseRowViewModel : CDP4CommonView.DomainOfExpertiseRowViewModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DomainOfExpertiseRowViewModel"/> class
+        /// </summary>
+        /// <param name="domainOfExpertise">The <see cref="DomainOfExpertise"/> associated with this row</param>
+        /// <param name="session">The session</param>
+        /// <param name="containerViewModel">The <see cref="IViewModelBase{Thing}"/> that is the container of this <see cref="IRowViewModelBase{Thing}"/></param>
+        public DomainOfExpertiseRowViewModel(DomainOfExpertise domainOfExpertise, ISession session, IViewModelBase<Thing> containerViewModel) 
+            : base(domainOfExpertise, session, containerViewModel)
+        {
+        }
+
+        /// <summary>
+        /// Updates the child <see cref="Participant"s/>
+        /// </summary>
+        /// <param name="participants">The <see cref="Participant"/>s to update with</param>
+        public void UpdateParticipants(IEnumerable<Participant> participants)
+        {
+            var domainParticipants = participants.Where(p => p.Domain.Contains(this.Thing));
+            var currentParticipants = this.ContainedRows.Select(r => r.Thing).OfType<Participant>();
+
+            var newParticipants = domainParticipants.Except(currentParticipants).ToList();
+            var oldParticipants = currentParticipants.Except(domainParticipants).ToList();
+
+            foreach (var participant in oldParticipants)
+            {
+                var row = this.ContainedRows.SingleOrDefault(r => r.Thing == participant);
+                if (row != null)
+                {
+                    this.ContainedRows.RemoveAndDispose(row);
+                }
+            }
+
+            foreach (var participant in newParticipants)
+            {
+                this.ContainedRows.Add(new ModelParticipantRowViewModel(participant, this.Session, this, showDomains: false));
+            }
+        }
+
+        /// <summary>
+        /// Indicates if edit functions in context menu are active
+        /// </summary>
+        public override bool CanEditThing { get; } = false;
+    }
+}

--- a/CDP4SiteDirectory/ViewModels/ModelBrowser/Rows/EngineeringModelSetupRowViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/ModelBrowser/Rows/EngineeringModelSetupRowViewModel.cs
@@ -1,21 +1,47 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="EngineeringModelSetupRowViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Simon Wood
+//
+//    This file is part of CDP4-IME Community Edition.
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4SiteDirectory.ViewModels
 {
+    using System.Collections.Generic;
     using System.Linq;
+
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
+
     using CDP4CommonView;
     using CDP4Composition.Converters;
     using CDP4Composition.Mvvm;
+
     using CDP4Dal;
     using CDP4Dal.Events;
+
     using ReactiveUI;
+
     using FolderRowViewModel = CDP4Composition.FolderRowViewModel;
+    using DomainOfExpertiseRowViewModel = ModelBrowser.Rows.DomainOfExpertiseRowViewModel;
 
     /// <summary>
     /// The Row-view-model representing a <see cref="EngineeringModelSetup"/>
@@ -178,6 +204,8 @@ namespace CDP4SiteDirectory.ViewModels
                 this.AddOrganization(organization);
             }
 
+            UpdateDomainParticipants(this.Thing.Participant);
+
             var orderedCollection = this.activeDomainFolderRow.ContainedRows.OfType<DomainOfExpertiseRowViewModel>().OrderBy(x => x.Name).ToArray();
             this.activeDomainFolderRow.ContainedRows.ClearWithoutDispose();
             this.activeDomainFolderRow.ContainedRows.AddRange(orderedCollection);
@@ -266,6 +294,18 @@ namespace CDP4SiteDirectory.ViewModels
         {
             var row = new DomainOfExpertiseRowViewModel(domain, this.Session, this);
             this.activeDomainFolderRow.ContainedRows.Add(row);
+        }
+
+        /// <summary>
+        /// Updates the <see cref="DomainOfExpertiseRowViewModel/> with <see cref="Participant"/>s
+        /// </summary>
+        /// <param name="participants">The <see cref="Participant"/>s</param>
+        private void UpdateDomainParticipants(IEnumerable<Participant> participants)
+        {
+            foreach(var domain in this.activeDomainFolderRow.ContainedRows.OfType<DomainOfExpertiseRowViewModel>())
+            {
+                domain.UpdateParticipants(participants);
+            }
         }
 
         /// <summary>

--- a/CDP4SiteDirectory/ViewModels/ModelBrowser/Rows/EngineeringModelSetupRowViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/ModelBrowser/Rows/EngineeringModelSetupRowViewModel.cs
@@ -204,7 +204,7 @@ namespace CDP4SiteDirectory.ViewModels
                 this.AddOrganization(organization);
             }
 
-            UpdateDomainParticipants(this.Thing.Participant);
+            this.UpdateDomainParticipants(this.Thing.Participant);
 
             var orderedCollection = this.activeDomainFolderRow.ContainedRows.OfType<DomainOfExpertiseRowViewModel>().OrderBy(x => x.Name).ToArray();
             this.activeDomainFolderRow.ContainedRows.ClearWithoutDispose();

--- a/CDP4SiteDirectory/ViewModels/ModelBrowser/Rows/ModelParticipantRowViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/ModelBrowser/Rows/ModelParticipantRowViewModel.cs
@@ -127,7 +127,7 @@ namespace CDP4SiteDirectory.ViewModels
                 this.RoleShortName = this.Role.ShortName;
             }
 
-            if (showDomains)
+            if (this.showDomains)
             {
                 foreach (var domain in this.Thing.Domain)
                 {

--- a/CDP4SiteDirectory/ViewModels/ModelBrowser/Rows/ModelParticipantRowViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/ModelBrowser/Rows/ModelParticipantRowViewModel.cs
@@ -1,6 +1,25 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ModelParticipantRowViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Simon Wood
+//
+//    This file is part of CDP4-IME Community Edition.
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -9,11 +28,17 @@ namespace CDP4SiteDirectory.ViewModels
     using System;
     using System.Linq;
     using System.Reactive.Linq;
+
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
+
     using CDP4Composition.Mvvm;
+
     using CDP4Dal;
     using CDP4Dal.Events;
+
+    using CDP4SiteDirectory.ViewModels.ModelBrowser.Rows;
+
     using ReactiveUI;
 
     /// <summary>
@@ -31,6 +56,11 @@ namespace CDP4SiteDirectory.ViewModels
         /// Backing field for <see cref="Name"/>
         /// </summary>
         private string name;
+
+        /// <summary>
+        /// Indicates if the domain of expertise should be shown as subnodes
+        /// </summary>
+        private readonly bool showDomains;
         #endregion
 
         #region Constructors
@@ -40,9 +70,10 @@ namespace CDP4SiteDirectory.ViewModels
         /// <param name="participant">The <see cref="Participant"/> this is associated to</param>
         /// <param name="session">The session</param>
         /// <param name="containerViewModel">The container <see cref="IViewModelBase{T}"/></param>
-        public ModelParticipantRowViewModel(Participant participant, ISession session, IViewModelBase<Thing> containerViewModel)
+        public ModelParticipantRowViewModel(Participant participant, ISession session, IViewModelBase<Thing> containerViewModel, bool showDomains = true)
             : base(participant, session, containerViewModel)
         {
+            this.showDomains = showDomains;
             this.UpdateProperties();
         }
         #endregion
@@ -70,8 +101,10 @@ namespace CDP4SiteDirectory.ViewModels
         /// </summary>
         private void UpdateProperties()
         {
+            this.ContainedRows.ClearAndDispose();
+
             var person = this.Thing.Person;
-            if (person == null)
+            if (person is null)
             {
                 // its normally impossible
                 return;
@@ -81,9 +114,8 @@ namespace CDP4SiteDirectory.ViewModels
             var surname = person.Surname ?? string.Empty;
             var organizationName = (person.Organization == null) ? "none" : person.Organization.Name;
 
-            this.Name = givenname + " " + surname;
-            this.Description = string.Format("DoE: {0}, Organization: {1}",
-                string.Join(", ", this.Thing.Domain.Select(x => x.Name)), organizationName);
+            this.Name = $"{givenname} {surname}";
+            this.Description = $"Organization: {organizationName}";
 
             this.RowStatus = (this.Thing.IsActive && person.IsActive && !person.IsDeprecated)
                 ? RowStatusKind.Active
@@ -93,6 +125,14 @@ namespace CDP4SiteDirectory.ViewModels
             {
                 this.RoleName = this.Role.Name;
                 this.RoleShortName = this.Role.ShortName;
+            }
+
+            if (showDomains)
+            {
+                foreach (var domain in this.Thing.Domain)
+                {
+                    this.ContainedRows.Add(new DomainOfExpertiseRowViewModel(domain, this.Session, this));
+                }
             }
         }
 

--- a/CDP4SiteDirectory/Views/ModelBrowser/ModelBrowser.xaml
+++ b/CDP4SiteDirectory/Views/ModelBrowser/ModelBrowser.xaml
@@ -68,7 +68,8 @@
                 </dx:MeasurePixelSnapper>
             </HierarchicalDataTemplate>
 
-            <HierarchicalDataTemplate DataType="{x:Type viewModels:ModelParticipantRowViewModel}">
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:ModelParticipantRowViewModel}" 
+                                      ItemsSource="{Binding ContainedRows}">
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
@@ -114,7 +115,8 @@
                 </dx:MeasurePixelSnapper>
             </HierarchicalDataTemplate>
 
-            <HierarchicalDataTemplate DataType="{x:Type CDP4CommonView:DomainOfExpertiseRowViewModel}">
+            <HierarchicalDataTemplate DataType="{x:Type CDP4CommonView:DomainOfExpertiseRowViewModel}"
+                                      ItemsSource="{Binding ContainedRows}">
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Engineering model layout changes.
Participants now show DoE as child nodes
DoE rows also show participants as child nodes. Edit and depreciate menu options have been removed.