### PR TITLE
Allow drag drop of Categories onto diagram elements; fixes gh865

### DIFF
--- a/CDP4Composition.Tests/Diagram/Cdp4DiagramOrgChartBehaviorTestFixture.cs
+++ b/CDP4Composition.Tests/Diagram/Cdp4DiagramOrgChartBehaviorTestFixture.cs
@@ -26,6 +26,7 @@
 namespace CDP4Composition.Tests.Diagram
 {
     using System.Threading;
+    using System.Threading.Tasks;
     using System.Windows;
 
     using CDP4Common.DiagramData;
@@ -101,89 +102,106 @@ namespace CDP4Composition.Tests.Diagram
         }
 
         [Test]
-        public void VerifyThatHandleDropWorksForHandledIDropTarget()
+        public async Task VerifyThatHandleDropWorksForHandledIDropTarget()
         {
             this.diagramContentItem.Content = this.dropTarget.Object;
             this.diagramDropInfo.Setup(x => x.Handled).Returns(true);
 
-            Assert.IsTrue(this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object));
+            var assertion = await this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object);
+
+            Assert.IsTrue(assertion);
 
             this.dropTarget.Verify(x => x.Drop(this.diagramDropInfo.Object), Times.Once);
         }
 
         [Test]
-        public void VerifyThatHandleDropWorksForUnhandledIDropTarget()
+        public async Task VerifyThatHandleDropWorksForUnhandledIDropTarget()
         {
             this.diagramContentItem.Content = this.dropTarget.Object;
             this.diagramDropInfo.Setup(x => x.Handled).Returns(false);
 
-            Assert.IsFalse(this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object));
+            var assertion = await this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object);
+
+            Assert.IsFalse(assertion);
 
             this.dropTarget.Verify(x => x.Drop(this.diagramDropInfo.Object), Times.Once);
         }
 
         [Test]
-        public void VerifyThatHandleDropWorksForHandledIIDropTarget()
+        public async Task VerifyThatHandleDropWorksForHandledIIDropTarget()
         {
             this.diagramContentItem.Content = this.iDropTarget.Object;
             this.diagramDropInfo.Setup(x => x.Handled).Returns(true);
 
-            Assert.IsTrue(this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object));
+            var assertion = await this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object);
+
+            Assert.IsTrue(assertion);
 
             this.dropTarget.Verify(x => x.Drop(this.diagramDropInfo.Object), Times.Once);
         }
 
         [Test]
-        public void VerifyThatHandleDropWorksForUnhandledIIDropTarget()
+        public async Task VerifyThatHandleDropWorksForUnhandledIIDropTarget()
         {
             this.diagramContentItem.Content = this.iDropTarget.Object;
             this.diagramDropInfo.Setup(x => x.Handled).Returns(false);
 
-            Assert.IsFalse(this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object));
+            var assertion = await this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object);
+
+            Assert.IsFalse(assertion);
 
             this.dropTarget.Verify(x => x.Drop(this.diagramDropInfo.Object), Times.Once);
         }
 
         [Test]
-        public void VerifyThatHandleDropWorksForUnsupportedObject()
+        public async Task VerifyThatHandleDropWorksForUnsupportedObject()
         {
             this.diagramContentItem.Content = "";
-            Assert.IsFalse(this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object));
+
+            var assertion = await this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object);
+
+            Assert.IsFalse(assertion);
 
             this.dropTarget.Verify(x => x.Drop(this.diagramDropInfo.Object), Times.Never);
         }
 
         [Test]
-        public void VerifyThatHandleDropWorksForDiagramControl()
+        public async Task VerifyThatHandleDropWorksForDiagramControl()
         {
             this.diagramControl.DataContext = this.dropTarget.Object;
             this.cdp4DiagramOrgChartBehavior.Attach(this.diagramControl);
             this.diagramDropInfo.Setup(x => x.Handled).Returns(true);
 
-            Assert.IsTrue(this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object));
+            var assertion = await this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object);
+
+            Assert.IsTrue(assertion);
 
             this.dropTarget.Verify(x => x.Drop(this.diagramDropInfo.Object), Times.Once);
         }
 
         [Test]
-        public void VerifyThatHandleDropWorksForDiagramControlWithUnhandledEvent()
+        public async Task VerifyThatHandleDropWorksForDiagramControlWithUnhandledEvent()
         {
             this.diagramControl.DataContext = this.dropTarget.Object;
             this.cdp4DiagramOrgChartBehavior.Attach(this.diagramControl);
             this.diagramDropInfo.Setup(x => x.Handled).Returns(false);
 
-            Assert.IsFalse(this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object));
+            var assertion = await this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object);
+
+            Assert.IsFalse(assertion);
 
             this.dropTarget.Verify(x => x.Drop(this.diagramDropInfo.Object), Times.Once);
         }
 
         [Test]
-        public void VerifyThatHandleDropWorksForDiagramControlWithUnsupportedDataContext()
+        public async Task VerifyThatHandleDropWorksForDiagramControlWithUnsupportedDataContext()
         {
             this.diagramControl.DataContext = "";
             this.cdp4DiagramOrgChartBehavior.Attach(this.diagramControl);
 
-            Assert.IsFalse(this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object));
+            var assertion = await this.cdp4DiagramOrgChartBehavior.HandleDrop(this.diagramContentItem, this.diagramDropInfo.Object);
+
+            Assert.IsFalse(assertion);
 
             this.dropTarget.Verify(x => x.Drop(this.diagramDropInfo.Object), Times.Never);
         }

--- a/CDP4Composition/CommonView/Diagram/Cdp4DiagramOrgChartBehavior.cs
+++ b/CDP4Composition/CommonView/Diagram/Cdp4DiagramOrgChartBehavior.cs
@@ -30,6 +30,7 @@ namespace CDP4CommonView.Diagram
     using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.Linq;
+    using System.Threading.Tasks;
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Input;
@@ -932,7 +933,7 @@ namespace CDP4CommonView.Diagram
 
             if (source is DiagramContentItem { Content: IIDropTarget controlHavingDropTarget })
             {
-                controlHavingDropTarget.DropTarget.DragOver(dropInfo);
+                controlHavingDropTarget.DropTarget?.DragOver(dropInfo);
 
                 if (dropInfo.Handled)
                 {
@@ -998,11 +999,11 @@ namespace CDP4CommonView.Diagram
         /// <remarks>
         /// Occurs when the input system reports an underlying drop event with this element as the drop target.
         /// </remarks>
-        private void PreviewDrop(object sender, DragEventArgs e)
+        private async void PreviewDrop(object sender, DragEventArgs e)
         {
             var dropInfo = new DiagramDropInfo(sender, e);
 
-            e.Handled = this.HandleDrop(e.Source, dropInfo);
+            e.Handled = await this.HandleDrop(e.Source, dropInfo);
         }
 
         /// <summary>
@@ -1011,11 +1012,11 @@ namespace CDP4CommonView.Diagram
         /// <param name="source">The source <see cref="object"/> that originated the Drop action.</param>
         /// <param name="dropInfo">The <see cref="DiagramDropInfo"/> object that was created based on the Drop action.</param>
         /// <returns>true if the Drop action was handled, otherwise false</returns>
-        public virtual bool HandleDrop(object source, IDiagramDropInfo dropInfo)
+        public virtual async Task<bool> HandleDrop(object source, IDiagramDropInfo dropInfo)
         {
             if (source is DiagramContentItem { Content: IDropTarget controlDropTarget })
             {
-                controlDropTarget.Drop(dropInfo);
+                await controlDropTarget.Drop(dropInfo);
 
                 if (dropInfo.Handled)
                 {
@@ -1025,7 +1026,7 @@ namespace CDP4CommonView.Diagram
 
             if (source is DiagramContentItem { Content: IIDropTarget controlHavingDropTarget })
             {
-                controlHavingDropTarget.DropTarget.Drop(dropInfo);
+                await controlHavingDropTarget.DropTarget.Drop(dropInfo);
 
                 if (dropInfo.Handled)
                 {
@@ -1035,7 +1036,7 @@ namespace CDP4CommonView.Diagram
 
             if (this.AssociatedObject?.DataContext is IDropTarget vmDropTarget)
             {
-                vmDropTarget.Drop(dropInfo);
+                await vmDropTarget.Drop(dropInfo);
             }
 
             return dropInfo.Handled;

--- a/CDP4Composition/Diagram/ElementDefinitionDiagramContentItem.cs
+++ b/CDP4Composition/Diagram/ElementDefinitionDiagramContentItem.cs
@@ -43,7 +43,7 @@ namespace CDP4Composition.Diagram
     /// <summary>
     /// Represents an <see cref="ElementDefinition"/> to be used in a Diagram
     /// </summary>
-    public class ElementDefinitionDiagramContentItem : PortContainerDiagramContentItem, IDiagramContentItemChildren, IIDropTarget
+    public class ElementDefinitionDiagramContentItem : PortContainerDiagramContentItem, IDiagramContentItemChildren
     {
         /// <summary>
         /// The <see cref="ISession"/> to be used when creating other view models
@@ -59,11 +59,6 @@ namespace CDP4Composition.Diagram
         /// Gets or sets the Children of the <see cref="ElementDefinitionDiagramContentItem"/>
         /// </summary>
         public ReactiveList<IDiagramContentItemChild> DiagramContentItemChildren { get; set; } = new();
-
-        /// <summary>
-        /// A specific class that handles the <see cref="IDropTarget"/> functionality
-        /// </summary>
-        public IDropTarget DropTarget { get; protected set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NamedThingDiagramContentItem"/> class.

--- a/CDP4Composition/Diagram/ElementDefinitionDropTarget.cs
+++ b/CDP4Composition/Diagram/ElementDefinitionDropTarget.cs
@@ -103,6 +103,32 @@ namespace CDP4Composition.Diagram
             {
                 await this.ParameterDrop(dropInfo, parameterTypeAndScale);
             }
+
+            if (dropInfo.Payload is Category category)
+            {
+                await this.CategoryDrop(dropInfo, category);
+            }
+
+            dropInfo.Handled = true;
+        }
+
+        /// <summary>
+        /// Handle the drop of a <see cref="Category"/>
+        /// </summary>
+        /// <param name="dropInfo">The <see cref="IDropInfo"/> containing the payload</param>
+        /// <param name="category">The <see cref="Category"/></param>
+        private async Task CategoryDrop(IDropInfo dropInfo, Category category)
+        {
+            if (this.elementDefinition.Category.Any(x => x.Equals(category)))
+            {
+                dropInfo.Effects = DragDropEffects.None;
+                return;
+            }
+
+            if (this.session.OpenIterations.TryGetValue(this.elementDefinition.GetContainerOfType<Iteration>(), out var tuple))
+            {
+                await this.thingCreator.ApplyCategory(category, this.elementDefinition, this.session);
+            }
         }
 
         /// <summary>
@@ -144,6 +170,51 @@ namespace CDP4Composition.Diagram
             {
                 this.ParameterDragOver(dropInfo, parameterTypeAndScale);
             }
+
+            if (dropInfo.Payload is Category category)
+            {
+                this.CategoryDragOver(dropInfo, category);
+            }
+        }
+
+        /// <summary>
+        /// Set the <see cref="IDropInfo.Effects"/> when the payload is an <see cref="Category"/>
+        /// </summary>
+        /// <param name="dropinfo">The <see cref="IDropInfo"/></param>
+        /// <param name="category">The <see cref="Category"/> in the payload</param>
+        private void CategoryDragOver(IDropInfo dropinfo, Category category)
+        {
+            // check if category is in the chain of rdls
+            var model = (EngineeringModel)this.elementDefinition.TopContainer;
+            var mrdl = model.EngineeringModelSetup.RequiredRdl.Single();
+            var rdlChains = new List<ReferenceDataLibrary> { mrdl };
+            rdlChains.AddRange(mrdl.RequiredRdls);
+
+            if (!rdlChains.Contains(category.Container))
+            {
+                dropinfo.Effects = DragDropEffects.None;
+
+                Logger.Warn("A category cannot be applied as it is not available in the current set of available reference data libraries.");
+                return;
+            }
+
+            if (!this.permissionService.CanWrite(this.elementDefinition))
+            {
+                dropinfo.Effects = DragDropEffects.None;
+                Logger.Warn("You do not have permission to apply the category.");
+                return;
+            }
+
+            // A category is already applied
+            if (this.elementDefinition.Category.Any(x => x.Equals(category)))
+            {
+                Logger.Warn("The category is already applied.");
+                dropinfo.Effects = DragDropEffects.None;
+                return;
+            }
+
+            dropinfo.Effects = DragDropEffects.Copy;
+            dropinfo.Handled = true;
         }
 
         /// <summary>
@@ -162,7 +233,7 @@ namespace CDP4Composition.Diagram
             if (!rdlChains.Contains(tuple.Item1.Container))
             {
                 dropinfo.Effects = DragDropEffects.None;
-                Logger.Warn("A parameter with the current parameter type cannot be created as the parameter type does not belong to the available libraries.");
+                Logger.Warn("A parameter with the current parameter type cannot be created as the parameter type does not belong in the current set of available reference data libraries..");
                 return;
             }
 

--- a/CDP4Composition/Diagram/ThingDiagramContentItem.cs
+++ b/CDP4Composition/Diagram/ThingDiagramContentItem.cs
@@ -34,6 +34,8 @@ namespace CDP4Composition.Diagram
     using CDP4Common.CommonData;
     using CDP4Common.DiagramData;
 
+    using CDP4Composition.DragDrop;
+
     using CDP4Dal;
     using CDP4Dal.Events;
     using CDP4Dal.Operations;
@@ -50,7 +52,7 @@ namespace CDP4Composition.Diagram
     /// <summary>
     /// Represents a diagram content control class that can store a <see cref="Thing"/>.
     /// </summary>
-    public abstract class ThingDiagramContentItem : DiagramContentItem, IThingDiagramItem, IReactiveObject, IDisposable
+    public abstract class ThingDiagramContentItem : DiagramContentItem, IThingDiagramItem, IReactiveObject, IDisposable, IIDropTarget
     {
         /// <summary> 
         /// <see cref="ReactiveUI.PropertyChangingEventHandler"/> event
@@ -153,6 +155,11 @@ namespace CDP4Composition.Diagram
         /// The observable for when the position of the view object changed
         /// </summary>
         public IDisposable PositionObservable { get; set; }
+
+        /// <summary>
+        /// A specific class that handles the <see cref="IDropTarget"/> functionality
+        /// </summary>
+        public IDropTarget DropTarget { get; protected set; }
 
         /// <summary>
         /// Initialize subscriptions

--- a/CDP4Composition/Services/IThingCreator.cs
+++ b/CDP4Composition/Services/IThingCreator.cs
@@ -7,6 +7,8 @@
 namespace CDP4Composition.Services
 {
     using System.Threading.Tasks;
+
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
     using CDP4Dal;
@@ -38,6 +40,20 @@ namespace CDP4Composition.Services
         /// The <see cref="ISession"/> in which the current <see cref="Parameter"/> is to be added
         /// </param>
         Task CreateParameter(ElementDefinition elementDefinition, ParameterGroup group, ParameterType parameterType, MeasurementScale measurementScale, DomainOfExpertise owner, ISession session);
+
+        /// <summary>
+        /// Apply <see cref="Category"/> to <see cref="ICategorizableThing"/>
+        /// </summary>
+        /// <param name="category">
+        /// The <see cref="Category"/> to apply
+        /// </param>
+        /// <param name="categorizableThing">
+        /// The <see cref="ICategorizableThing"/> that the category is applied to.
+        /// </param>
+        /// <param name="session">
+        /// The <see cref="ISession"/> in which the new <see cref="Category"/> application is to be added to
+        /// </param>
+        Task ApplyCategory<T>(Category category, T categorizableThing, ISession session) where T : Thing, ICategorizableThing;
 
         /// <summary>
         /// Create a new <see cref="UserRuleVerification"/>

--- a/CDP4DiagramEditor/Views/DiagramEditor.xaml
+++ b/CDP4DiagramEditor/Views/DiagramEditor.xaml
@@ -76,7 +76,7 @@
                                VerticalAlignment="Center" Margin="10,0,10,2" />
                     <TextBlock Text="{Binding ClassKind}" FontSize="12" HorizontalAlignment="Center"
                                VerticalAlignment="Center" Margin="10,0,10,2" />
-                    <TextBlock Text="{Binding Categories}" FontSize="12" HorizontalAlignment="Center"
+                    <TextBlock Text="{Binding Categories}" FontSize="12" HorizontalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center"
                                VerticalAlignment="Center" Margin="10,0,10,10" />
                     <TextBlock Text="{Binding FullName}" TextAlignment="Center" FontWeight="Bold" FontSize="14"
                                Margin="10,0,10,10" />

--- a/EngineeringModel.Tests/ViewModels/ElementDefinitionTreeRows/ElementDefinitionRowViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/ElementDefinitionTreeRows/ElementDefinitionRowViewModelTestFixture.cs
@@ -351,6 +351,23 @@ namespace CDP4EngineeringModel.Tests.ViewModels.ElementDefinitionTreeRows
         }
 
         /// <summary>
+        /// Apply <see cref="Category"/> to <see cref="ICategorizableThing"/>
+        /// </summary>
+        /// <param name="category">
+        /// The <see cref="Category"/> to apply
+        /// </param>
+        /// <param name="categorizableThing">
+        /// The <see cref="ICategorizableThing"/> that the category is applied to.
+        /// </param>
+        /// <param name="session">
+        /// The <see cref="ISession"/> in which the new <see cref="Category"/> application is to be added to
+        /// </param>
+        public Task ApplyCategory<T>(Category category, T categorizableThing, ISession session) where T : Thing, ICategorizableThing
+        {
+            throw new Exception("The category could not be applied");
+        }
+
+        /// <summary>
         /// Create a new <see cref="UserRuleVerification"/>
         /// </summary>
         /// <param name="ruleVerificationList">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
Allow drag drop of Categories onto diagram elements; fixes #865 
