### PR TITLE
[Fix] React to all changes of a parameter type in the product tree; fixes #960

### DIFF
--- a/ProductTree/ViewModels/ProductTreeRows/ParameterOrOverrideBaseRowViewModel.cs
+++ b/ProductTree/ViewModels/ProductTreeRows/ParameterOrOverrideBaseRowViewModel.cs
@@ -242,7 +242,7 @@ namespace CDP4ProductTree.ViewModels
             var parameterTypeListener = CDPMessageBus.Current.Listen<ObjectChangedEvent>(this.Thing.ParameterType)
                 .Where(objectChange => objectChange.EventKind == EventKind.Updated)
                 .ObserveOn(RxApp.MainThreadScheduler)
-                .Subscribe(x => this.PopulateValueSetProperty());
+                .Subscribe(x => this.UpdateProperties());
 
             this.Disposables.Add(parameterTypeListener);
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
React to all changes of a parameter type in the product tree