### PR TITLE
Fix multiselect dragdrop behavior in ED trees.

### DIFF
--- a/CDP4Composition/DragDrop/FrameworkElementDragBehavior.cs
+++ b/CDP4Composition/DragDrop/FrameworkElementDragBehavior.cs
@@ -106,6 +106,7 @@ namespace CDP4Composition.DragDrop
                 if (Math.Abs(position.X - dragStart.X) > SystemParameters.MinimumHorizontalDragDistance
                     || Math.Abs(position.Y - dragStart.Y) > SystemParameters.MinimumVerticalDragDistance)
                 {
+                    this.dragInfo.Effects = DragDropEffects.All;
                     var dragSource = this.AssociatedObject.DataContext as IDragSource;
                     if (dragSource != null)
                     {

--- a/CDP4Composition/DragDrop/TreeListSelectionStrategyRowDragDrop.cs
+++ b/CDP4Composition/DragDrop/TreeListSelectionStrategyRowDragDrop.cs
@@ -1,0 +1,76 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TreeListSelectionStrategyRowDragDrop.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2022 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed, Simon Wood
+// 
+//    This file is part of COMET-IME Community Edition.
+//    The COMET-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//    The COMET-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+// 
+//    The COMET-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.DragDrop
+{
+    using System.Windows;
+    using System.Windows.Input;
+
+    using DevExpress.Xpf.Core;
+    using DevExpress.Xpf.Grid;
+    using DevExpress.Xpf.Grid.TreeList;
+
+    /// <summary>
+    /// Extended row selection strategy that override mouse down and up behaviors when using Ctrl key
+    /// </summary>
+    public class TreeListSelectionStrategyRowDragDrop : TreeListSelectionStrategyRow
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TreeListSelectionStrategyRowDragDrop"/> class
+        /// </summary>
+        /// <param name="view">The tre view</param>
+        public TreeListSelectionStrategyRowDragDrop(TreeListView view) : base(view)
+        {
+        }
+
+        /// <summary>
+        /// Override of the Left mouse button down behavior
+        /// </summary>
+        /// <param name="hitInfo">The hitinfo</param>
+        protected override void OnAfterMouseLeftButtonDownCore(IDataViewHitInfo hitInfo)
+        {
+            if (Keyboard2.IsControlPressed)
+            {
+                return;
+            }
+
+            base.OnAfterMouseLeftButtonDownCore(hitInfo);
+        }
+
+        /// <summary>
+        /// Override of the Left mouse button up behavior
+        /// </summary>
+        /// <param name="e">The mouse args</param>
+        public override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
+        {
+            if (Keyboard2.IsControlPressed)
+            {
+                base.OnAfterMouseLeftButtonDownCore(((TreeListView)this.view).CalcHitInfo((DependencyObject)e.OriginalSource));
+            }
+
+            base.OnMouseLeftButtonUp(e);
+        }
+    }
+}

--- a/CDP4Composition/DragDrop/TreeListViewDragDrop.cs
+++ b/CDP4Composition/DragDrop/TreeListViewDragDrop.cs
@@ -1,0 +1,47 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TreeListViewDragDrop.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2022 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed, Simon Wood
+// 
+//    This file is part of COMET-IME Community Edition.
+//    The COMET-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+// 
+//    The COMET-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+// 
+//    The COMET-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.DragDrop
+{
+    using DevExpress.Xpf.Grid;
+    using DevExpress.Xpf.Grid.Native;
+    using DevExpress.Xpf.Grid.TreeList;
+
+    /// <summary>
+    /// A special implementation of the TreeListView that enables overrides on mouse up to fix Ctrl-enabled drag-drop
+    /// </summary>
+    public class TreeListViewDragDrop : TreeListView
+    {
+        /// <summary>
+        /// Selection strategy override
+        /// </summary>
+        /// <returns>The Selection strategy of rows</returns>
+        protected override SelectionStrategyBase CreateSelectionStrategy()
+        {
+            var result = base.CreateSelectionStrategy();
+            return result is TreeListSelectionStrategyRow ? new TreeListSelectionStrategyRowDragDrop(this) : result;
+        }
+    }
+}

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementDefinitionRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementDefinitionRowViewModel.cs
@@ -31,6 +31,8 @@ namespace CDP4EngineeringModel.ViewModels
     using ReactiveUI;
     using Utilities;
 
+    using IDropTarget = CDP4Composition.DragDrop.IDropTarget;
+
     /// <summary>
     /// The row representing an <see cref="ElementDefinition"/>
     /// </summary>
@@ -128,6 +130,12 @@ namespace CDP4EngineeringModel.ViewModels
                 return;
             }
 
+            if (dropInfo.Payload is List<ElementDefinition> list)
+            {
+                this.DragOver(dropInfo, list[0]);
+                return;
+            }
+
             if (dropInfo.Payload is ElementDefinition elementDefinition)
             {
                 this.DragOver(dropInfo, elementDefinition);
@@ -167,6 +175,14 @@ namespace CDP4EngineeringModel.ViewModels
             if (dropInfo.Payload is Tuple<ParameterType, MeasurementScale> parameterTypeAndScale)
             {
                 await this.Drop(dropInfo, parameterTypeAndScale);
+            }
+
+            if (dropInfo.Payload is List<ElementDefinition> list)
+            {
+                foreach (var definition in list)
+                {
+                    await this.Drop(dropInfo, definition);
+                }
             }
 
             if (dropInfo.Payload is ElementDefinition elementDefinition)
@@ -336,12 +352,6 @@ namespace CDP4EngineeringModel.ViewModels
                 return;
             }
 
-            if (!iteration.Element.Contains(elementDefinition))
-            {
-                dropinfo.Effects = DragDropEffects.None;
-                return;
-            }
-
             if (elementDefinition.TopContainer == this.Thing.TopContainer)
             {
                 dropinfo.Effects = elementDefinition.HasUsageOf(this.Thing)
@@ -350,7 +360,14 @@ namespace CDP4EngineeringModel.ViewModels
             }
             else
             {
+                // copying from another EM
                 dropinfo.Effects = DragDropEffects.Copy;
+                return;
+            }
+
+            if (!iteration.Element.Contains(elementDefinition))
+            {
+                dropinfo.Effects = DragDropEffects.None;
             }
         }
 

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementDefinitionRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementDefinitionRowViewModel.cs
@@ -9,6 +9,7 @@ namespace CDP4EngineeringModel.ViewModels
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
     using System.Threading.Tasks;
     using System.Windows;
 
@@ -293,6 +294,33 @@ namespace CDP4EngineeringModel.ViewModels
             // add new parameters
             var addedParameters = definedParameterWithoutSubscription.Except(currentParameter).ToList();
             this.AddParameterBase(addedParameters);
+        }
+
+        /// <summary>
+        /// Update this <see cref="Tooltip"/> with extra information.
+        /// </summary>
+        protected override void UpdateTooltip()
+        {
+            base.UpdateTooltip();
+
+            var sb = new StringBuilder(this.Tooltip);
+
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine("When dragging and dropping Element Definitions between models, the following modifier keys can be used:");
+            sb.AppendLine();
+            sb.AppendLine("- None: The ownership in the target model is set to the Active Domain. The values are set to the default \"-\".");
+            sb.AppendLine();
+            sb.AppendLine("- Ctrl: The ownership in the target model is set to the Active Domain. The values are set to values as defined in the source Model.");
+            sb.AppendLine();
+            sb.AppendLine("- Shift: The ownership in the target model is set to the ownership as defined in the source model. The values are set to the default \"-\".");
+            sb.AppendLine();
+            sb.AppendLine("- Ctrl + Shift: The ownership in the target model is set to the ownership as defined in the source model. The values are set to values as defined in the source Model.");
+            sb.AppendLine();
+            sb.AppendLine("NOTE: The Element Definition is always copied, including the contained Element Usages and Parameters.");
+            sb.AppendLine("NOTE: This functionality is only supported if the target server is COMET.");
+
+            this.Tooltip = sb.ToString();
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
@@ -392,6 +392,15 @@ namespace CDP4EngineeringModel.ViewModels
                     }
                 }
 
+                var list = dropInfo.Payload as List<ElementDefinition>;
+                if (list != null && list.Any())
+                {
+                    dropInfo.Effects = list.First().TopContainer == this.Thing.TopContainer
+                            ? DragDropEffects.None
+                            : DragDropEffects.Copy;
+                        return;
+                }
+
                 dropInfo.Effects = DragDropEffects.None;
             }
             catch (Exception ex)

--- a/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
+++ b/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
@@ -214,7 +214,7 @@
                     <cdp4Composition:ContextMenuBehavior />
                 </dxmvvm:Interaction.Behaviors>
                 <dxg:TreeListControl.View>
-                    <dxg:TreeListView Name="View"
+                    <dragDrop:TreeListViewDragDrop Name="View"
                                       AllowEditing="False"
                                       AutoWidth="False"
                                       EditorShowMode="MouseUpFocused"
@@ -260,7 +260,7 @@
                             <cdp4Composition:TreeCellEditBehavior />
                             <cdp4Composition:TreeCellShowingEditorBehavior/>
                         </dxmvvm:Interaction.Behaviors>
-                    </dxg:TreeListView>
+                    </dragDrop:TreeListViewDragDrop>
                 </dxg:TreeListControl.View>
                 <dxg:TreeListControl.Columns>
                     <dxg:TreeListColumn FieldName="Name" Fixed="Left">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

- Pressing CTRL while dragging now does not deselect rows and cancel the drag #768 
- Dropping ED from browser to browser does not require to drop on empty space now
- You can also multi drop EDs to create EUs now

