### PR TITLE
SplashScreen Improvements

### DIFF
--- a/CDP4Composition/Composition/COMETBootstrapper.cs
+++ b/CDP4Composition/Composition/COMETBootstrapper.cs
@@ -68,6 +68,7 @@ namespace CDP4Composition.Composition
 
             var sw = Stopwatch.StartNew();
             this.UpdateBootstrapperStatus("Loading COMET Catalogs");
+            this.ShowStatusMessage("Loading COMET IME Components...");
 
             this.AddExecutingAssemblyCatalog(catalog);
             this.AddCustomCatalogs(catalog);
@@ -75,10 +76,14 @@ namespace CDP4Composition.Composition
             this.UpdateBootstrapperStatus($"COMET Catalogs loaded in: {sw.ElapsedMilliseconds} [ms]");
 
             this.ConfigureServiceLocator(container);
+            this.ShowStatusMessage("Loading COMET IME Plugins...");
 
             this.AddPluginCatalogs(catalog);
 
             this.UpdateBootstrapperStatus("Composing parts");
+            this.ResetStatusProgress();
+            this.ShowStatusMessage("Initializing COMET IME Plugins...");
+
             container.ComposeParts();
 
             this.UpdateBootstrapperStatus("Initializing modules");
@@ -122,15 +127,22 @@ namespace CDP4Composition.Composition
         private void AddPluginCatalogs(AggregateCatalog catalog)
         {
             this.UpdateBootstrapperStatus("Loading COMET Plugins");
-
+            
             var pluginLoader = new PluginLoader<T>();
+            this.ResetStatusProgress();
+            var counter = 1;
 
             foreach (var directoryCatalog in pluginLoader.DirectoryCatalogues)
             {
                 try
                 {
+                    this.SetStatusProgress(counter, pluginLoader.DirectoryCatalogues.Count);
+                    this.ShowStatusMessage($"Loading Plugin: {Path.GetFileName(directoryCatalog.FullPath)}");
+
                     catalog.Catalogs.Add(directoryCatalog);
                     this.UpdateBootstrapperStatus($"DirectoryCatalogue {directoryCatalog.FullPath} Loaded");
+                                        
+                    counter++;
                 }
                 catch (ReflectionTypeLoadException reflectionTypeLoadException)
                 {
@@ -139,6 +151,7 @@ namespace CDP4Composition.Composition
             }
 
             this.UpdateBootstrapperStatus($"{pluginLoader.DirectoryCatalogues.Count} COMET Plugins Loaded");
+            this.ShowStatusMessage($"{pluginLoader.DirectoryCatalogues.Count} COMET Plugins Loaded");
         }
 
         /// <summary>
@@ -159,6 +172,33 @@ namespace CDP4Composition.Composition
         {
             this.status = message;
             this.logger.Debug(this.status);
+        }
+
+        /// <summary>
+        /// Show a status message to user, more display friendly than the logs. To be used for splash screens etc.
+        /// </summary>
+        /// <param name="message">The message to show</param>
+        protected virtual void ShowStatusMessage(string message)
+        {
+            // do nothing in base class
+        }
+
+        /// <summary>
+        /// Resets any progress bars to a determinate or indeterminate state and applies max value
+        /// </summary>
+        protected virtual void ResetStatusProgress()
+        {
+            // do nothing in base class
+        }
+
+        /// <summary>
+        /// Sets the progress bar indicator to value
+        /// </summary>
+        /// <param name="value">The value to set the progress bar to</param>
+        /// <param name="maxValue">The max value of the progress bar</param>
+        protected virtual void SetStatusProgress(int value, int maxValue = 100)
+        {
+            // do nothing in base class
         }
 
         /// <summary>

--- a/CDP4IME/CDP4IMEBootstrapper.cs
+++ b/CDP4IME/CDP4IMEBootstrapper.cs
@@ -54,7 +54,7 @@ namespace CDP4IME
         /// <param name="container">The <see cref="AggregateCatalog"/></param>
         protected override void OnComposed(CompositionContainer container)
         {
-            this.UpdateBootstrapperStatus("Creating the Shell");
+            this.UpdateBootstrapperStatus("Starting COMET IME");
             Application.Current.MainWindow = container.GetExportedValue<Shell>();
         }
 
@@ -65,7 +65,33 @@ namespace CDP4IME
         protected override void UpdateBootstrapperStatus(string message)
         {
             base.UpdateBootstrapperStatus(message);
+        }
+
+        /// <summary>
+        /// Show meesage in splash screen
+        /// </summary>
+        /// <param name="message">The message</param>
+        protected override void ShowStatusMessage(string message)
+        {
             DXSplashScreen.SetState(message);
+        }
+
+        /// <summary>
+        /// Resets any progress bars to a determinate or indeterminate state and applies max value 0
+        /// </summary>
+        protected override void ResetStatusProgress()
+        {
+            DXSplashScreen.Progress(0, 0);
+        }
+
+        /// <summary>
+        /// Sets the progress bar indicator to value
+        /// </summary>
+        /// <param name="value">The value to set the progress bar to</param>
+        /// <param name="maxValue">The max value to set the progress bar to</param>
+        protected override void SetStatusProgress(int value, int maxValue = 100)
+        {
+            DXSplashScreen.Progress(value, maxValue);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Minor improvements in splashscreen:

- Decouple logging and splash status to make logs more techy and splash messages more informative for regular user
- Plugin names no longer full path but just name
- Progress bar actually shows live progress on plugin loading

![image](https://user-images.githubusercontent.com/22167021/168281988-cda0198d-b151-4c22-922f-b1eb9cb12723.png)

