### PR TITLE
[Improvement] Open Model straight after connecting to data source

### DIFF
--- a/CDP4Addin/OfficeRibbon/AddinRibbonPart.cs
+++ b/CDP4Addin/OfficeRibbon/AddinRibbonPart.cs
@@ -116,7 +116,7 @@ namespace CDP4AddinCE
                     break;
                 case "CDP4_SelectModelToOpen":
                     var sessionsOpening = new List<ISession> { this.session };
-                    var modelOpeningDialogViewModel = new ModelOpeningDialogViewModel(sessionsOpening);
+                    var modelOpeningDialogViewModel = new ModelOpeningDialogViewModel(sessionsOpening, null);
                     var modelOpeningDialogViewModelResult = this.DialogNavigationService.NavigateModal(modelOpeningDialogViewModel) as DataSourceSelectionResult;
                     break;
                 case "CDP4_SelectModelToClose":

--- a/CDP4IME.Tests/ShellViewModelTestFixture.cs
+++ b/CDP4IME.Tests/ShellViewModelTestFixture.cs
@@ -216,6 +216,26 @@ namespace CDP4IME.Tests
         }
 
         [Test]
+        public void VerifyThatOpenDataSourceCommandExecutesOpenModelAndSessionIsLoaded()
+        {
+            Assert.IsFalse(this.viewModel.HasSessions);
+
+            var mockedSession = new Mock<ISession>();
+            var selectionResult = new DataSourceSelectionResult(true, mockedSession.Object, true);
+
+            this.navigationService.Setup(x => x.NavigateModal(It.IsAny<DataSourceSelectionViewModel>())).Returns(selectionResult);
+            this.viewModel.OpenDataSourceCommand.Execute(null);
+            this.navigationService.Verify(x => x.NavigateModal(It.IsAny<DataSourceSelectionViewModel>()));
+
+            this.navigationService.Verify(x => x.NavigateModal(It.IsAny<ModelOpeningDialogViewModel>()));
+            CollectionAssert.IsNotEmpty(this.viewModel.Sessions);
+
+            Assert.IsTrue(this.viewModel.HasSessions);
+
+            Assert.AreEqual(mockedSession.Object, this.viewModel.SelectedSession.Session);
+        }
+
+        [Test]
         public void VerifyThatExecuteOpenAboutRequestNavigatesToAboutWindow()
         {
             this.viewModel.OpenAboutCommand.Execute(null);

--- a/CDP4IME/ShellViewModel.cs
+++ b/CDP4IME/ShellViewModel.cs
@@ -184,7 +184,7 @@ namespace CDP4IME
             this.OpenPluginManagerCommand.Subscribe(_ => this.ExecuteOpenPluginManagerRequest());
 
             this.OpenSelectIterationsCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.HasSessions));
-            this.OpenSelectIterationsCommand.Subscribe(_ => this.ExecuteOpenSelectIterationsCommand());
+            this.OpenSelectIterationsCommand.Subscribe(s => this.ExecuteOpenSelectIterationsCommand(s as ISession));
 
             this.CloseIterationsCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.HasOpenIterations));
             this.CloseIterationsCommand.Subscribe(_ => this.ExecuteCloseIterationsCommand());
@@ -420,6 +420,11 @@ namespace CDP4IME
 
             this.Sessions.Add(new SessionViewModel(result.Session));
             this.SelectedSession = this.Sessions.First();
+
+            if (result.OpenModel)
+            {
+                this.OpenSelectIterationsCommand.Execute(result.Session);
+            }
         }
 
         /// <summary>
@@ -463,11 +468,10 @@ namespace CDP4IME
         /// <summary>
         /// Executes the <see cref="OpenSelectIterationsCommand"/> command
         /// </summary>
-        private void ExecuteOpenSelectIterationsCommand()
+        private void ExecuteOpenSelectIterationsCommand(ISession session)
         {
-            var dialogService = ServiceLocator.Current.GetInstance<IDialogNavigationService>();
-            var modelSelectionViewModel = new ModelOpeningDialogViewModel(this.OpenSessions);
-            dialogService.NavigateModal(modelSelectionViewModel);
+            var modelSelectionViewModel = new ModelOpeningDialogViewModel(this.OpenSessions, session);
+            this.dialogNavigationService.NavigateModal(modelSelectionViewModel);
         }
 
         /// <summary>
@@ -475,9 +479,8 @@ namespace CDP4IME
         /// </summary>
         private void ExecuteCloseIterationsCommand()
         {
-            var dialogService = ServiceLocator.Current.GetInstance<IDialogNavigationService>();
             var modelSelectionViewModel = new ModelClosingDialogViewModel(this.OpenSessions);
-            dialogService.NavigateModal(modelSelectionViewModel);
+            this.dialogNavigationService.NavigateModal(modelSelectionViewModel);
         }
 
         /// <summary>
@@ -485,9 +488,8 @@ namespace CDP4IME
         /// </summary>
         private void ExecuteOpenDomainSwitchDialogCommand()
         {
-            var dialogService = ServiceLocator.Current.GetInstance<IDialogNavigationService>();
             var domainSwitchViewModel = new ModelIterationDomainSwitchDialogViewModel(this.OpenSessions);
-            dialogService.NavigateModal(domainSwitchViewModel);
+            this.dialogNavigationService.NavigateModal(domainSwitchViewModel);
         }
 
         /// <summary>

--- a/CDP4ShellDialogs/ViewModels/DialogResult/DataSourceSelectionResult.cs
+++ b/CDP4ShellDialogs/ViewModels/DialogResult/DataSourceSelectionResult.cs
@@ -20,15 +20,21 @@ namespace CDP4ShellDialogs.ViewModels
         /// </summary>
         /// <param name="res">An instance of <see cref="Nullable{T}"/> that gives the action of the user</param>
         /// <param name="session">The <see cref="ISession"/> that was opened</param>
-        public DataSourceSelectionResult(bool? res, ISession session)
+        public DataSourceSelectionResult(bool? res, ISession session, bool openModel = false)
             : base(res)
         {
             this.Session = session;
+            this.OpenModel = openModel;
         }
 
         /// <summary>
         /// Gets the <see cref="ISession"/> that was opened
         /// </summary>
         public ISession Session { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether to open the model selection dialog
+        /// </summary>
+        public bool OpenModel { get; private set; }
     }
 }

--- a/CDP4ShellDialogs/ViewModels/ModelOpeningDialogViewModel.cs
+++ b/CDP4ShellDialogs/ViewModels/ModelOpeningDialogViewModel.cs
@@ -91,7 +91,10 @@ namespace CDP4ShellDialogs.ViewModels
         /// <param name="sessionAvailable">
         /// The session Available.
         /// </param>
-        public ModelOpeningDialogViewModel(IEnumerable<ISession> sessionAvailable)
+        /// <param name="preselectedSession">
+        /// A <see cref="ISession"/> that should be preselected.
+        /// </param>
+        public ModelOpeningDialogViewModel(IEnumerable<ISession> sessionAvailable, ISession preselectedSession)
         {
             this.SessionsAvailable = new DisposableReactiveList<ModelSelectionSessionRowViewModel>();
             this.SelectedIterations = new ReactiveList<IViewModelBase<Thing>>();
@@ -133,6 +136,11 @@ namespace CDP4ShellDialogs.ViewModels
             this.WhenAnyValue(x => x.IsModelScreen).Subscribe(x => this.IsIterationScreen = !x);
 
             this.PopulateSessionsRowViewModel(sessionAvailable);
+
+            if (preselectedSession != null)
+            {
+                this.SelectedRowSession = this.SessionsAvailable.FirstOrDefault(s => s.Session.Equals(preselectedSession));
+            }
         }
 
         /// <summary>

--- a/CDP4ShellDialogs/Views/DataSourceSelection.xaml
+++ b/CDP4ShellDialogs/Views/DataSourceSelection.xaml
@@ -74,7 +74,7 @@
                                                      Command="{Binding BrowseSourceCommand,
                                               UpdateSourceTrigger=PropertyChanged}"
                                                      Content="..."
-                                                     ToolTip="Browse for Source File"
+                                                     ToolTip="Browse for source file."
                                                      Visibility="{Binding ShowBrowseButton,
                                                  UpdateSourceTrigger=PropertyChanged,
                                                  Converter={dx:BooleanToVisibilityConverter}}"
@@ -86,7 +86,7 @@
                                                      Command="{Binding OpenUriManagerCommand,
                                                    UpdateSourceTrigger=PropertyChanged}"
                                                      Content="..."
-                                                     ToolTip="Open URI Manager"
+                                                     ToolTip="Open URI manager."
                                                      Glyph="{dx:DXImage Image=ManageDatasource_16x16.png}" />
                                     <!---->
                                 </Grid>
@@ -118,7 +118,8 @@
                                                        Converter={dx:BooleanToVisibilityConverter}}" />
                                     <dx:SimpleButton x:Name="ShowPasswordBox"
                                               Grid.Column="1"
-                                              Margin="10,0,10,0"                                              
+                                              Margin="10,0,10,0"
+                                                     ToolTip="Show password in clear text."
                                               IsChecked="{Binding IsPasswordVisible}"
                                               Content="{Binding ShowPasswordButtonText}"
                                               ButtonKind="Toggle"/>
@@ -160,7 +161,7 @@
                                                      Width="35"
                                                      HorizontalAlignment="Right"
                                                      Glyph="{dx:DXImage Image=ManageDatasource_16x16.png}"
-                                                     ToolTip="Configure Proxy"
+                                                     ToolTip="Configure proxy."
                                                      Command="{Binding OpenProxyConfigurationCommand,
                                                UpdateSourceTrigger=PropertyChanged}"
                                                      Content="..." />
@@ -178,13 +179,24 @@
                             </dxlc:LayoutItem>
                         </dxlc:LayoutGroup>
                         <dxlc:LayoutGroup Margin="0,10,0,0" Orientation="Horizontal">
-                            <dx:SimpleButton MinWidth="75"
+                            
+                            <dx:SplitButton MinWidth="75"
                                              MinHeight="25"
-                                             MaxWidth="75"
+                                             MaxWidth="300"
                                              MaxHeight="25"
                                              HorizontalAlignment="Right"
+                                            ToolTip="Connect to the Data Source and immediately select an Iteration to open."
+                                             Command="{Binding Path=OkAndOpenCommand}"
+                                             Content="Connect and Open Model" IsDefault="True" ButtonKind="Simple">
+                                <dx:SimpleButton MinWidth="75"
+                                             MinHeight="25"
+                                             MaxHeight="25"
+                                             HorizontalAlignment="Stretch"
                                              Command="{Binding Path=OkCommand}"
-                                             Content="OK" IsDefault="True" />
+                                                 ToolTip="Connect to the Data Source without directly opening an Iteration."
+                                             Content="Connect Without Opening" IsDefault="False" />
+
+                            </dx:SplitButton>
                             <dx:SimpleButton MinWidth="75"
                                              MinHeight="25"
                                              MaxWidth="75"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Added default control to data source dialog to go to open model dialog after connecting.

![quickbake2](https://user-images.githubusercontent.com/22167021/168308123-490eecc9-6334-4c64-8fef-292f227de430.gif)

