### PR TITLE
Add null check for category in element definition tree; fixes #1028

### DIFF
--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementUsageRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementUsageRowViewModel.cs
@@ -185,7 +185,18 @@ namespace CDP4EngineeringModel.ViewModels
         /// Gets an <see cref="IEnumerable{T}"/> containing all applied categories for this <see cref="ElementUsage"/>
         /// and its according <see cref="ElementDefinition"/>.
         /// </summary>
-        public new IEnumerable<Category> Category => this.Thing.Category.Union(this.Thing.ElementDefinition.Category).Distinct();
+        public new IEnumerable<Category> Category
+        {
+            get
+            {
+                if (this.Thing != null)
+                {
+                    return this.Thing.Category.Union(this.Thing.ElementDefinition.Category).Distinct();
+                }
+
+                return new List<Category>();
+            }
+        }
 
         /// <summary>
         /// Gets or sets the Categories in display format


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Add null check for the category in the ElementDefinition tree.
<!-- Thanks for contributing to COMET-IME! -->

