### PR TITLE
[PERFORMANCE] Implement PropertyChanged instead of Observable; fixes #1087

### DIFF
--- a/CDP4Composition/Mvvm/RowViewModelBase.cs
+++ b/CDP4Composition/Mvvm/RowViewModelBase.cs
@@ -428,8 +428,6 @@ namespace CDP4Composition.Mvvm
                     this.HasError = !string.IsNullOrEmpty(this.ErrorMsg);
                 }
             };
-
-            this.ThrownExceptions.Subscribe(e => logger.Error(e));
         }
 
         /// <summary>

--- a/CDP4Composition/Mvvm/RowViewModelBase.cs
+++ b/CDP4Composition/Mvvm/RowViewModelBase.cs
@@ -78,7 +78,7 @@ namespace CDP4Composition.Mvvm
         /// <summary>
         /// Out property for the <see cref="HasError"/> property
         /// </summary>
-        private ObservableAsPropertyHelper<bool> hasError;
+        private bool hasError;
 
         /// <summary>
         /// Backing property for the <see cref="IsHighlighted"/>
@@ -184,7 +184,8 @@ namespace CDP4Composition.Mvvm
         /// </summary>
         public bool HasError
         {
-            get { return this.hasError.Value; }
+            get { return this.hasError; }
+            set { this.RaiseAndSetIfChanged(ref this.hasError, value); }
         }
 
         /// <summary>
@@ -420,11 +421,15 @@ namespace CDP4Composition.Mvvm
                         objectChange => this.UpdateThingStatus())));
             }
 
-            this.WhenAnyValue(vm => vm.ErrorMsg)
-                .Select(x => !string.IsNullOrEmpty(x))
-                .ToProperty(this, x => x.HasError, out this.hasError);
+            this.PropertyChanged += (sender, args) =>
+            {
+                if (args.PropertyName == nameof(this.ErrorMsg))
+                {
+                    this.HasError = !string.IsNullOrEmpty(this.ErrorMsg);
+                }
+            };
 
-            this.hasError.ThrownExceptions.Subscribe(e => logger.Error(e));
+            this.ThrownExceptions.Subscribe(e => logger.Error(e));
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementBaseRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementBaseRowViewModel.cs
@@ -128,7 +128,15 @@ namespace CDP4EngineeringModel.ViewModels
             this.currentDomain = currentDomain;
             this.UpdateOwnerProperties();
             this.UpdateObfuscationProperties();
-            this.WhenAnyValue(vm => vm.Owner).Subscribe(_ => this.UpdateOwnerProperties());
+            
+            this.PropertyChanged += (sender, args) =>
+            {
+                if (args.PropertyName == nameof(this.Owner))
+                {
+                    this.UpdateOwnerProperties();
+                }
+            };
+
             this.UpdateModelCode();
         }
 

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementUsageRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementUsageRowViewModel.cs
@@ -101,10 +101,14 @@ namespace CDP4EngineeringModel.ViewModels
             this.ExcludedOptions = new ReactiveList<Option>();
             this.SelectedOptions = new ReactiveList<Option>();
 
-            this.WhenAnyValue(vm => vm.SelectedOptions).Subscribe(_ => this.ExcludedOptions = new ReactiveList<Option>(this.AllOptions.Except(this.SelectedOptions)));
+            this.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(this.SelectedOptions))
+                {
+                    this.ExcludedOptions = new ReactiveList<Option>(this.AllOptions.Except(this.SelectedOptions));
+                }
 
-            this.WhenAnyValue(vm => vm.ExcludedOptions).Subscribe(
-                _ =>
+                if (e.PropertyName == nameof(this.ExcludedOptions))
                 {
                     if (!this.SelectedOptions.Any())
                     {
@@ -126,9 +130,10 @@ namespace CDP4EngineeringModel.ViewModels
                             this.OptionToolTip = "This ElementUsage is used in all options.";
                         }
                     }
-                });
 
-            this.WhenAnyValue(vm => vm.ExcludedOptions).Skip(1).Subscribe(_ => this.SendUpdateExcludedOptionOperation());
+                    this.SendUpdateExcludedOptionOperation();
+                }
+            };
 
             this.UpdateOptionLists();
             this.PopulateParameterGroups();

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterComponentValueRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterComponentValueRowViewModel.cs
@@ -119,42 +119,41 @@ namespace CDP4EngineeringModel.ViewModels
             this.Option = this.ActualOption;
             this.State = (this.ActualState != null) ? this.ActualState.Name : string.Empty;
 
-            this.WhenAnyValue(x => x.Switch).Skip(1).Subscribe(
-                x =>
+            this.PropertyChanged += (sender, args) =>
+            {
+                if (args.PropertyName == nameof(this.Switch))
                 {
-                    var valueBaseRow = this.ContainerViewModel as ParameterValueBaseRowViewModel;
-                    if (valueBaseRow != null)
+                    if (this.ContainerViewModel is ParameterValueBaseRowViewModel valueBaseRow)
                     {
                         foreach (ParameterComponentValueRowViewModel row in valueBaseRow.ContainedRows)
                         {
-                            row.Switch = x;
+                            row.Switch = this.Switch;
                         }
 
                         return;
                     }
 
-                    var parameterBaseRow = this.ContainerViewModel as ParameterOrOverrideBaseRowViewModel;
-                    if (parameterBaseRow != null)
+                    if (this.ContainerViewModel is ParameterOrOverrideBaseRowViewModel parameterBaseRow)
                     {
                         foreach (ParameterComponentValueRowViewModel row in parameterBaseRow.ContainedRows)
                         {
-                            row.Switch = x;
+                            row.Switch = this.Switch;
                         }
 
                         return;
                     }
 
-                    var subscriptionRow = this.ContainerViewModel as ParameterSubscriptionRowViewModel;
-                    if (subscriptionRow != null)
+                    if (this.ContainerViewModel is ParameterSubscriptionRowViewModel subscriptionRow)
                     {
                         foreach (ParameterComponentValueRowViewModel row in subscriptionRow.ContainedRows)
                         {
-                            row.Switch = x;
+                            row.Switch = this.Switch;
                         }
 
                         return;
                     }
-                });
+                }
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Performance improvement by using PropertyChanged implementation instead of ReactiveUI Observables.