### PR TITLE
[FIX] Requirements verification causes exception if no top element is set

### DIFF
--- a/CDP4Composition/Services/DownloadFileService/DownloadFileService.cs
+++ b/CDP4Composition/Services/DownloadFileService/DownloadFileService.cs
@@ -54,7 +54,7 @@ namespace CDP4Composition.Services
         protected static Logger Logger = LogManager.GetLogger(typeof(DownloadFileService).FullName);
 
         /// <summary>
-        /// The (injected) <see cref="DevExpress.Mvvm.IMessageBoxService"/>
+        /// The <see cref="IMessageBoxService"/> used to show user messages.
         /// </summary>
         private readonly IMessageBoxService messageBoxService = ServiceLocator.Current.GetInstance<IMessageBoxService>();
 

--- a/Requirements.Tests/RequirementBrowser/RequirementsBrowserViewModelTestFixture.cs
+++ b/Requirements.Tests/RequirementBrowser/RequirementsBrowserViewModelTestFixture.cs
@@ -262,7 +262,7 @@ namespace CDP4Requirements.Tests.RequirementBrowser
             
             Assert.AreEqual(RequirementStateOfCompliance.Unknown, reqSpecRow.RequirementStateOfCompliance);
             
-            messageBoxService.Verify(
+            this.messageBoxService.Verify(
                 x => x.Show(
                     It.IsAny<string>(),
                     It.IsAny<string>(),

--- a/Requirements.Tests/RequirementBrowser/RequirementsBrowserViewModelTestFixture.cs
+++ b/Requirements.Tests/RequirementBrowser/RequirementsBrowserViewModelTestFixture.cs
@@ -30,7 +30,7 @@ namespace CDP4Requirements.Tests.RequirementBrowser
     using System.Collections.Generic;
     using System.Linq;
     using System.Reactive.Concurrency;
-    
+    using System.Windows;
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
@@ -38,16 +38,16 @@ namespace CDP4Requirements.Tests.RequirementBrowser
 
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
-
+    using CDP4Composition.Services;
     using CDP4Dal;
     using CDP4Dal.Events;
     using CDP4Dal.Operations;
     using CDP4Dal.Permission;
 
     using CDP4Requirements.ViewModels;
-
+    
     using CDP4RequirementsVerification;
-
+    using Microsoft.Practices.ServiceLocation;
     using Moq;
 
     using NUnit.Framework;
@@ -73,9 +73,11 @@ namespace CDP4Requirements.Tests.RequirementBrowser
         private Assembler assembler;
         private Mock<ISession> session;
         private Participant participant;
+        private Mock<IServiceLocator> serviceLocator;
         private Mock<IThingDialogNavigationService> dialogNavigation;
         private Mock<IPanelNavigationService> panelNavigation;
         private Mock<IPermissionService> permissionService;
+        private Mock<IMessageBoxService> messageBoxService;
         private Person person;
         private Option option;
 
@@ -92,6 +94,12 @@ namespace CDP4Requirements.Tests.RequirementBrowser
             this.permissionService.Setup(x => x.CanRead(It.IsAny<Thing>())).Returns(true);
             this.permissionService.Setup(x => x.CanWrite(It.IsAny<Thing>())).Returns(true);
             this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(true);
+
+            this.serviceLocator = new Mock<IServiceLocator>();
+            ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
+
+            this.messageBoxService = new Mock<IMessageBoxService>();
+            this.serviceLocator.Setup(x => x.GetInstance<IMessageBoxService>()).Returns(this.messageBoxService.Object);
 
             this.session = new Mock<ISession>();
 
@@ -239,6 +247,29 @@ namespace CDP4Requirements.Tests.RequirementBrowser
 
             vm.ExecuteVerifyRequirements(this.iteration.DefaultOption);
             Assert.AreEqual(RequirementStateOfCompliance.Unknown, reqSpecRow.RequirementStateOfCompliance);
+        }
+
+        [Test]
+        public void VerifyThatNoTopElementSetResultsInMessageBox()
+        {
+            this.iteration.TopElement = null;
+
+            var vm = new RequirementsBrowserViewModel(this.iteration, this.session.Object, this.dialogNavigation.Object, this.panelNavigation.Object, null, null);
+            var reqSpecRow = vm.ReqSpecificationRows.Single();
+
+            Assert.IsTrue(vm.CanVerifyRequirements);
+            vm.ExecuteVerifyRequirements(this.iteration.DefaultOption);
+            
+            Assert.AreEqual(RequirementStateOfCompliance.Unknown, reqSpecRow.RequirementStateOfCompliance);
+            
+            messageBoxService.Verify(
+                x => x.Show(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<MessageBoxButton>(),
+                    MessageBoxImage.Error
+                    )
+                );
         }
     }
 }

--- a/Requirements.Tests/RequirementBrowser/RequirementsBrowserViewModelTestFixture.cs
+++ b/Requirements.Tests/RequirementBrowser/RequirementsBrowserViewModelTestFixture.cs
@@ -267,7 +267,7 @@ namespace CDP4Requirements.Tests.RequirementBrowser
                     It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<MessageBoxButton>(),
-                    MessageBoxImage.Error
+                    MessageBoxImage.Warning
                     )
                 );
         }

--- a/Requirements.Tests/Requirements.Tests.csproj
+++ b/Requirements.Tests/Requirements.Tests.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.IO.Compression" />

--- a/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
@@ -757,7 +757,7 @@ namespace CDP4Requirements.ViewModels
                     ElementDefinition topElement = ((Iteration)option.Container).TopElement;
                     if (topElement == null)
                     {
-                        this.messageBoxService.Show("Requirements can't be verified.\nTop Element is not set.", "Verification failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                        this.messageBoxService.Show("Verification not performed.\nTop Element is not set.", "Verification failed", MessageBoxButton.OK, MessageBoxImage.Warning);
                         return;
                     }
 
@@ -776,7 +776,7 @@ namespace CDP4Requirements.ViewModels
                 }
                 catch (NestedElementTreeException e)
                 {
-                    this.messageBoxService.Show($"Requirements can't be verified.\n{e.Message}", "Verification failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                    this.messageBoxService.Show($"Verification not performed.\n{e.Message}", "Verification failed", MessageBoxButton.OK, MessageBoxImage.Warning);
                 }
                 finally
                 {

--- a/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
@@ -35,6 +35,7 @@ namespace CDP4Requirements.ViewModels
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.Exceptions;
     using CDP4Common.ReportingData;
     using CDP4Common.SiteDirectoryData;
     
@@ -47,7 +48,7 @@ namespace CDP4Requirements.ViewModels
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
-    
+    using CDP4Composition.Services;
     using CDP4Dal;
     using CDP4Dal.Events;
     using CDP4Dal.Operations;
@@ -60,7 +61,7 @@ namespace CDP4Requirements.ViewModels
     using CDP4RequirementsVerification;
     using CDP4RequirementsVerification.Events;
     using CDP4RequirementsVerification.Verifiers;
-
+    using Microsoft.Practices.ServiceLocation;
     using NLog;
     
     using ReactiveUI;
@@ -75,6 +76,11 @@ namespace CDP4Requirements.ViewModels
         /// The logger for the current class
         /// </summary>
         private static Logger logger = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// The <see cref="IMessageBoxService"/> used to show user messages.
+        /// </summary>
+        private readonly IMessageBoxService messageBoxService;
 
         /// <summary>
         ///  The comparer for <see cref="RequirementsSpecification"/>
@@ -164,6 +170,7 @@ namespace CDP4Requirements.ViewModels
             var model = (EngineeringModel)this.Thing.Container;
             this.ActiveParticipant = model.GetActiveParticipant(this.Session.ActivePerson);
             this.openRequirementsSpecificationEditorViewModels = new List<RequirementsSpecificationEditorViewModel>();
+            this.messageBoxService = ServiceLocator.Current.GetInstance<IMessageBoxService>();
 
             this.ExecuteLongRunningDispatcherAction(
                 () => 
@@ -747,6 +754,13 @@ namespace CDP4Requirements.ViewModels
 
                     var targetOption = option as Option;
 
+                    ElementDefinition topElement = ((Iteration)option.Container).TopElement;
+                    if (topElement == null)
+                    {
+                        this.messageBoxService.Show("Requirements can't be verified.\nTop Element is not set.", "Verification failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
+                    }
+
                     var configuration = new RequirementVerificationConfiguration
                     {
                         Option = targetOption
@@ -759,6 +773,10 @@ namespace CDP4Requirements.ViewModels
                     }
 
                     await Task.WhenAll(tasks.ToArray());
+                }
+                catch (NestedElementTreeException e)
+                {
+                    this.messageBoxService.Show($"Requirements can't be verified.\n{e.Message}", "Verification failed", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
                 finally
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Now a message box with error description will be displayed and verification will be aborted.

