### PR TITLE
Add the Definition and Alias of en ElementDefinition on the basic tab so that a user does not need to click through to get that information

### DIFF
--- a/BasicRdl/Views/Dialogs/ArrayParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/ArrayParameterTypeDialog.xaml
@@ -159,7 +159,8 @@
                 </dxlc:LayoutItem>
 
                 <items:IsDeprecatedLayoutItem />
-
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/BinaryRelationshipRuleDialog.xaml
+++ b/BasicRdl/Views/Dialogs/BinaryRelationshipRuleDialog.xaml
@@ -161,7 +161,8 @@
                 <items:IsDeprecatedLayoutItem />
 
                 <items:ShortNameContainerLayoutItem />
-
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
 
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/BooleanParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/BooleanParameterTypeDialog.xaml
@@ -27,6 +27,8 @@
                 <items:SymbolLayoutItem/>
                 <items:ShortNameContainerLayoutItem />
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/CategoryDialog.xaml
+++ b/BasicRdl/Views/Dialogs/CategoryDialog.xaml
@@ -38,7 +38,8 @@
                                    IsReadOnly="{Binding IsReadOnly}" />
                 </lc:LayoutItem>
                 <items:ShortNameContainerLayoutItem />
-
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
             <lc:LayoutGroup Header="Permissible Classes" Orientation="Vertical">
                 <lc:LayoutItem>

--- a/BasicRdl/Views/Dialogs/CompoundParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/CompoundParameterTypeDialog.xaml
@@ -173,7 +173,8 @@
                 </dxlc:LayoutItem>
 
                 <items:IsDeprecatedLayoutItem/>
-
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/ConstantDialog.xaml
+++ b/BasicRdl/Views/Dialogs/ConstantDialog.xaml
@@ -76,6 +76,8 @@
                         </dxg:GridControl.Columns>
                     </dxg:GridControl>
                 </lc:LayoutItem>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/CyclicRatioScaleDialog.xaml
+++ b/BasicRdl/Views/Dialogs/CyclicRatioScaleDialog.xaml
@@ -47,6 +47,8 @@
                 </dxlc:LayoutItem>
                 
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:ValueDefinitionLayoutGroup/>
             <items:MappingToReferenceScaleLayoutGroup/>

--- a/BasicRdl/Views/Dialogs/DateParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/DateParameterTypeDialog.xaml
@@ -27,6 +27,8 @@
                 <items:SymbolLayoutItem/>
                 <items:ShortNameContainerLayoutItem />
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/DateTimeParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/DateTimeParameterTypeDialog.xaml
@@ -27,6 +27,8 @@
                 <items:SymbolLayoutItem/>
                 <items:ShortNameContainerLayoutItem />
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/DecompositionRuleDialog.xaml
+++ b/BasicRdl/Views/Dialogs/DecompositionRuleDialog.xaml
@@ -117,6 +117,8 @@
                 </lc:LayoutItem>
 
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
             
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/DerivedQuantityKindDialog.xaml
+++ b/BasicRdl/Views/Dialogs/DerivedQuantityKindDialog.xaml
@@ -41,6 +41,8 @@
                 </dxlc:LayoutItem>
                 <items:IsDeprecatedLayoutItem />
                 <items:ScaleLayoutItem/>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <dxlc:LayoutGroup Name="QuantityKindFactors" Header="Factors" Orientation="Vertical">
                 <dxlc:LayoutItem>

--- a/BasicRdl/Views/Dialogs/DerivedUnitDialog.xaml
+++ b/BasicRdl/Views/Dialogs/DerivedUnitDialog.xaml
@@ -114,6 +114,8 @@
 
                     </dxg:GridControl.Columns>
                 </dxg:GridControl>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
 
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/EnumerationParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/EnumerationParameterTypeDialog.xaml
@@ -33,6 +33,8 @@
                     <dxe:CheckEdit Name="AllowMultiSelect" IsChecked="{Binding Path=AllowMultiSelect, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </dxlc:LayoutItem>
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <dxlc:LayoutGroup Name="EnumerationValueDefinitions" Header="Values" Orientation="Vertical">
                 <dxlc:LayoutItem>

--- a/BasicRdl/Views/Dialogs/EnumerationValueDefinitionDialog.xaml
+++ b/BasicRdl/Views/Dialogs/EnumerationValueDefinitionDialog.xaml
@@ -21,6 +21,8 @@
             <lc:LayoutGroup Header="Basic" Orientation="Vertical">
                 <items:NameLayoutItem/>
                 <items:ShortNameLayoutItem/>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
             <items:AliasLayoutGroup/>
             <items:DefinitionLayoutGroup/>

--- a/BasicRdl/Views/Dialogs/FileTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/FileTypeDialog.xaml
@@ -39,6 +39,8 @@
                 
                 <items:ShortNameContainerLayoutItem/>
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
             
             <items:CategoryLayoutGroup/>

--- a/BasicRdl/Views/Dialogs/GlossaryDialog.xaml
+++ b/BasicRdl/Views/Dialogs/GlossaryDialog.xaml
@@ -35,6 +35,8 @@
                 <items:NameLayoutItem />
                 <items:ShortNameContainerLayoutItem/>
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
 
             <lc:LayoutGroup Header="Terms" Orientation="Vertical">

--- a/BasicRdl/Views/Dialogs/IntervalScaleDialog.xaml
+++ b/BasicRdl/Views/Dialogs/IntervalScaleDialog.xaml
@@ -33,6 +33,8 @@
                 <items:IsMinimumInclusiveLayoutItem/>
                 <items:IsMaximumInclusiveLayoutItem />
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:ValueDefinitionLayoutGroup/>
             <items:MappingToReferenceScaleLayoutGroup/>

--- a/BasicRdl/Views/Dialogs/LinearConversionUnitDialog.xaml
+++ b/BasicRdl/Views/Dialogs/LinearConversionUnitDialog.xaml
@@ -66,12 +66,9 @@
                                   ShowError="True"/>
                 </dxlc:LayoutItem>
 
-
-
-
-
                 <items:IsDeprecatedLayoutItem />
-
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:AliasLayoutGroup />
             <items:DefinitionLayoutGroup />

--- a/BasicRdl/Views/Dialogs/LogarithmicScaleDialog.xaml
+++ b/BasicRdl/Views/Dialogs/LogarithmicScaleDialog.xaml
@@ -40,6 +40,8 @@
                 <items:IsMinimumInclusiveLayoutItem/>
                 <items:IsMaximumInclusiveLayoutItem />
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <dxlc:LayoutGroup Name="Logarithm" Header="Logarithm" Orientation="Vertical">
                 <dxlc:LayoutItem Label="Logarithm base:">

--- a/BasicRdl/Views/Dialogs/MultiRelationshipRuleDialog.xaml
+++ b/BasicRdl/Views/Dialogs/MultiRelationshipRuleDialog.xaml
@@ -77,6 +77,8 @@
                 </lc:LayoutItem>
 
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
 
             </lc:LayoutGroup>
 

--- a/BasicRdl/Views/Dialogs/OrdinalScaleDialog.xaml
+++ b/BasicRdl/Views/Dialogs/OrdinalScaleDialog.xaml
@@ -39,6 +39,8 @@
                                    IsReadOnly="{Binding IsReadOnly}"/>
                 </dxlc:LayoutItem>
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:ValueDefinitionLayoutGroup/>
             <items:MappingToReferenceScaleLayoutGroup/>

--- a/BasicRdl/Views/Dialogs/ParameterizedCategoryRuleDialog.xaml
+++ b/BasicRdl/Views/Dialogs/ParameterizedCategoryRuleDialog.xaml
@@ -104,6 +104,8 @@
                         </dxg:GridControl.View>
                     </dxg:GridControl>
                 </lc:LayoutItem>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
 
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/PrefixedUnitDialog.xaml
+++ b/BasicRdl/Views/Dialogs/PrefixedUnitDialog.xaml
@@ -109,7 +109,8 @@
                     </Grid>
                 </dxlc:LayoutItem>
                 <items:IsDeprecatedLayoutItem />
-
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:AliasLayoutGroup />
             <items:DefinitionLayoutGroup />

--- a/BasicRdl/Views/Dialogs/RatioScaleDialog.xaml
+++ b/BasicRdl/Views/Dialogs/RatioScaleDialog.xaml
@@ -33,6 +33,8 @@
                 <items:IsMinimumInclusiveLayoutItem/>
                 <items:IsMaximumInclusiveLayoutItem />
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:ValueDefinitionLayoutGroup/>
             <items:MappingToReferenceScaleLayoutGroup/>

--- a/BasicRdl/Views/Dialogs/ReferencerRuleDialog.xaml
+++ b/BasicRdl/Views/Dialogs/ReferencerRuleDialog.xaml
@@ -100,6 +100,8 @@
 
                 <items:IsDeprecatedLayoutItem />
 
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
 
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/SampledFunctionParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/SampledFunctionParameterTypeDialog.xaml
@@ -268,7 +268,8 @@
                 </dxlc:LayoutGroup>
 
                 <items:IsDeprecatedLayoutItem/>
-
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/ScaleValueDefinitionDialog.xaml
+++ b/BasicRdl/Views/Dialogs/ScaleValueDefinitionDialog.xaml
@@ -36,6 +36,8 @@
                                   Text="{Binding Path=ScaleValueDefinition, Mode=TwoWay, ValidatesOnDataErrors=True,UpdateSourceTrigger=PropertyChanged}"/>
                 </dxlc:LayoutItem>
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:AliasLayoutGroup />
             <items:DefinitionLayoutGroup />

--- a/BasicRdl/Views/Dialogs/SimpleQuantityKindDialog.xaml
+++ b/BasicRdl/Views/Dialogs/SimpleQuantityKindDialog.xaml
@@ -44,6 +44,8 @@
                 </dxlc:LayoutItem>
                 <items:IsDeprecatedLayoutItem />
                 <items:ScaleLayoutItem/>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/SimpleUnitDialog.xaml
+++ b/BasicRdl/Views/Dialogs/SimpleUnitDialog.xaml
@@ -23,6 +23,8 @@
                 <items:NameLayoutItem />
                 <items:ShortNameContainerLayoutItem />
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:AliasLayoutGroup />
             <items:DefinitionLayoutGroup />

--- a/BasicRdl/Views/Dialogs/SpecializedQuantityKindDialog.xaml
+++ b/BasicRdl/Views/Dialogs/SpecializedQuantityKindDialog.xaml
@@ -139,7 +139,8 @@
                 </dxlc:LayoutItem>
                 
                 <items:ScaleLayoutItem/>
-                
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/TermDialog.xaml
+++ b/BasicRdl/Views/Dialogs/TermDialog.xaml
@@ -30,6 +30,8 @@
                 <items:ShortNameLayoutItem />
                 <items:NameLayoutItem />
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
             
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/TextParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/TextParameterTypeDialog.xaml
@@ -27,6 +27,8 @@
                 <items:SymbolLayoutItem/>
                 <items:ShortNameContainerLayoutItem />
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/TimeOfDayParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/TimeOfDayParameterTypeDialog.xaml
@@ -26,6 +26,8 @@
                 <items:SymbolLayoutItem/>
                 <items:ShortNameContainerLayoutItem />
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup />

--- a/BasicRdl/Views/Dialogs/UnitPrefixDialog.xaml
+++ b/BasicRdl/Views/Dialogs/UnitPrefixDialog.xaml
@@ -38,6 +38,8 @@
                 </lc:LayoutItem>
                 <items:ShortNameContainerLayoutItem/>
                 <items:IsDeprecatedLayoutItem />
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
             
             <items:AliasLayoutGroup />

--- a/CDP4Composition/CDP4Composition.csproj
+++ b/CDP4Composition/CDP4Composition.csproj
@@ -378,6 +378,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="CommonView\Items\DefinitionDisplayLayoutItem.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="CommonView\Items\AliasLayoutGroup.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -459,6 +463,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="CommonView\Items\NumberSetLayoutItem.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="CommonView\Items\AliasDisplayLayoutItem.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -674,6 +682,8 @@
     <Compile Remove="obj\x64\Release\Views\SessionHeader.g.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="CommonView\Items\AliasDisplayLayoutItem.xaml" />
+    <None Remove="CommonView\Items\DefinitionDisplayLayoutItem.xaml" />
     <None Remove="Resources\Images\cometlogo.png" />
     <None Remove="Resources\Images\cometlogo_48x48.png" />
     <None Remove="Views\CustomFilterEditorDialog.xaml" />

--- a/CDP4Composition/CommonView/AutoGenDialogViewModel/DefinedThingDialogViewModel.cs
+++ b/CDP4Composition/CommonView/AutoGenDialogViewModel/DefinedThingDialogViewModel.cs
@@ -127,19 +127,6 @@ namespace CDP4CommonView
         }
 
         /// <summary>
-        /// Gets first <see cref="Alias"/> from <see cref="AliasRowViewModel"/>
-        /// and returns it and it's language code as a string
-        /// </summary>
-        public string FirstAlias
-        {
-            get
-            {
-                var firstAlias = this.Alias.FirstOrDefault();
-                return firstAlias == null ? string.Empty : $"{firstAlias.Content} [{firstAlias.LanguageCode}]";
-            }
-        }
-
-        /// <summary>
         /// Gets or sets the list of <see cref="Alias"/>
         /// </summary>
         public ReactiveList<AliasRowViewModel> Alias { get; protected set; }
@@ -151,19 +138,6 @@ namespace CDP4CommonView
         {
             get { return this.selectedDefinition; }
             set { this.RaiseAndSetIfChanged(ref this.selectedDefinition, value); }
-        }
-
-        /// <summary>
-        /// Gets first <see cref="Definition"/> from <see cref="DefinitionRowViewModel"/>
-        /// and returns it's content as a string
-        /// </summary>
-        public string FirstDefinition
-        {
-            get
-            {
-                var firstDefinition = this.Definition.FirstOrDefault();
-                return firstDefinition?.Content;
-            }
         }
 
         /// <summary>

--- a/CDP4Composition/CommonView/AutoGenDialogViewModel/DefinedThingDialogViewModel.cs
+++ b/CDP4Composition/CommonView/AutoGenDialogViewModel/DefinedThingDialogViewModel.cs
@@ -127,6 +127,19 @@ namespace CDP4CommonView
         }
 
         /// <summary>
+        /// Gets first <see cref="Alias"/> from <see cref="AliasRowViewModel"/>
+        /// and returns it and it's language code as a string
+        /// </summary>
+        public string FirstAlias
+        {
+            get
+            {
+                var firstAlias = this.Alias.FirstOrDefault();
+                return firstAlias == null ? string.Empty : $"{firstAlias.Content} [{firstAlias.LanguageCode}]";
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the list of <see cref="Alias"/>
         /// </summary>
         public ReactiveList<AliasRowViewModel> Alias { get; protected set; }
@@ -138,6 +151,19 @@ namespace CDP4CommonView
         {
             get { return this.selectedDefinition; }
             set { this.RaiseAndSetIfChanged(ref this.selectedDefinition, value); }
+        }
+
+        /// <summary>
+        /// Gets first <see cref="Definition"/> from <see cref="DefinitionRowViewModel"/>
+        /// and returns it's content as a string
+        /// </summary>
+        public string FirstDefinition
+        {
+            get
+            {
+                var firstDefinition = this.Definition.FirstOrDefault();
+                return firstDefinition?.Content;
+            }
         }
 
         /// <summary>

--- a/CDP4Composition/CommonView/Items/AliasDisplayLayoutItem.xaml
+++ b/CDP4Composition/CommonView/Items/AliasDisplayLayoutItem.xaml
@@ -1,0 +1,15 @@
+<dxlc:LayoutItem x:Class="CDP4CommonView.Items.DefinitionDisplayLayoutItem"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
+             xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+             xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+             mc:Ignorable="d"
+             Label="Definition: "
+             VerticalAlignment="Bottom">
+    <dxlc:LayoutItem.Resources>
+    </dxlc:LayoutItem.Resources>
+        <TextBlock Text="{Binding FirstDefinition}"></TextBlock>
+</dxlc:LayoutItem>

--- a/CDP4Composition/CommonView/Items/AliasDisplayLayoutItem.xaml.cs
+++ b/CDP4Composition/CommonView/Items/AliasDisplayLayoutItem.xaml.cs
@@ -1,8 +1,27 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="AliasDisplayLayoutItem.xaml.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2022 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Omar Elebiary, Antoine Théate, Jan Oratowski, Jaimer Bernar
+//
+//    This file is part of CDP4-IME Community Edition.
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4CommonView.Items
 {

--- a/CDP4Composition/CommonView/Items/AliasDisplayLayoutItem.xaml.cs
+++ b/CDP4Composition/CommonView/Items/AliasDisplayLayoutItem.xaml.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AliasDisplayLayoutItem.xaml.cs" company="RHEA System S.A.">
+//   Copyright (c) 2015 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4CommonView.Items
+{
+    using DevExpress.Xpf.LayoutControl;
+
+    /// <summary>
+    /// Interaction logic for AliasDisplayLayoutItem.xaml
+    /// </summary>
+    public partial class AliasDisplayLayoutItem : LayoutItem
+    {
+        public AliasDisplayLayoutItem()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/CDP4Composition/CommonView/Items/DefinitionDisplayLayoutItem.xaml
+++ b/CDP4Composition/CommonView/Items/DefinitionDisplayLayoutItem.xaml
@@ -1,0 +1,15 @@
+<dxlc:LayoutItem x:Class="CDP4CommonView.Items.AliasDisplayLayoutItem"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
+             xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+             xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+             mc:Ignorable="d"
+             Label="Alias: "
+             VerticalAlignment="Bottom">
+    <dxlc:LayoutItem.Resources>
+    </dxlc:LayoutItem.Resources>
+        <TextBlock Text="{Binding FirstAlias}"></TextBlock>
+</dxlc:LayoutItem>

--- a/CDP4Composition/CommonView/Items/DefinitionDisplayLayoutItem.xaml.cs
+++ b/CDP4Composition/CommonView/Items/DefinitionDisplayLayoutItem.xaml.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DefinitionDisplayLayoutItem.xaml.cs" company="RHEA System S.A.">
+//   Copyright (c) 2015 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4CommonView.Items
+{
+    using DevExpress.Xpf.LayoutControl;
+
+    /// <summary>
+    /// Interaction logic for DefinitionDisplayLayoutItem.xaml
+    /// </summary>
+    public partial class DefinitionDisplayLayoutItem : LayoutItem
+    {
+        public DefinitionDisplayLayoutItem()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/CDP4Composition/CommonView/Items/DefinitionDisplayLayoutItem.xaml.cs
+++ b/CDP4Composition/CommonView/Items/DefinitionDisplayLayoutItem.xaml.cs
@@ -1,8 +1,27 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DefinitionDisplayLayoutItem.xaml.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2022 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Omar Elebiary, Antoine Théate, Jan Oratowski, Jaimer Bernar
+//
+//    This file is part of CDP4-IME Community Edition.
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4CommonView.Items
 {

--- a/CDP4Composition/CommonView/ViewModels/DefinedThingDialogViewModel.cs
+++ b/CDP4Composition/CommonView/ViewModels/DefinedThingDialogViewModel.cs
@@ -33,6 +33,10 @@ namespace CDP4CommonView
 
     using CDP4Composition.Mvvm;
 
+    /// <summary>
+    /// dialog-view-model class representing a <see cref="DefinedThing"/>
+    /// this part of the class is not auto generated and will be persisted
+    /// </summary>
     public abstract partial class DefinedThingDialogViewModel<T> : DialogViewModelBase<T> where T : DefinedThing
     {
         /// <summary>

--- a/CDP4Composition/CommonView/ViewModels/DefinedThingDialogViewModel.cs
+++ b/CDP4Composition/CommonView/ViewModels/DefinedThingDialogViewModel.cs
@@ -1,0 +1,64 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DefinedThingDialogViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2022 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Omar Elebiary, Antoine Théate, Jan Oratowski, Jaimer Bernar
+//
+//    This file is part of CDP4-IME Community Edition.
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4CommonView
+{
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+
+    using CDP4CommonView;
+
+    using CDP4Composition.Mvvm;
+
+    public abstract partial class DefinedThingDialogViewModel<T> : DialogViewModelBase<T> where T : DefinedThing
+    {
+        /// <summary>
+        /// Gets first <see cref="Alias"/> from <see cref="AliasRowViewModel"/>
+        /// and returns it and it's language code as a string
+        /// </summary>
+        public string FirstAlias
+        {
+            get
+            {
+                var firstAlias = this.Alias.FirstOrDefault();
+                return firstAlias == null ? string.Empty : $"{firstAlias.Content} [{firstAlias.LanguageCode}]";
+            }
+        }
+
+        /// <summary>
+        /// Gets first <see cref="Definition"/> from <see cref="DefinitionRowViewModel"/>
+        /// and returns it's content as a string
+        /// </summary>
+        public string FirstDefinition
+        {
+            get
+            {
+                var firstDefinition = this.Definition.FirstOrDefault();
+                return firstDefinition?.Content;
+            }
+        }
+    }
+}

--- a/CDP4SiteDirectory/Views/Dialogs/DomainOfExpertiseDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/DomainOfExpertiseDialog.xaml
@@ -30,6 +30,8 @@
                 <items:ShortNameLayoutItem/>
                 <items:NameLayoutItem/>
                 <items:IsDeprecatedLayoutItem/>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
 
             <items:AliasLayoutGroup/>

--- a/CDP4SiteDirectory/Views/Dialogs/SiteReferenceDataLibraryDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/SiteReferenceDataLibraryDialog.xaml
@@ -63,6 +63,8 @@
                 </lc:LayoutItem>
                 
                 <items:IsDeprecatedLayoutItem/>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
 
             <items:AliasLayoutGroup/>

--- a/EngineeringModel/Views/Dialogs/ElementDefinitionDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/ElementDefinitionDialog.xaml
@@ -46,6 +46,8 @@
                                   Text="{Binding Path=ModelCode, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                                   IsReadOnly="True"/>
                 </lc:LayoutItem>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
             <items:CategoryLayoutGroup/>
             <lc:LayoutGroup Header="Organizations" Orientation="Vertical" IsEnabled="{Binding AreOrganizationsVisible}">

--- a/EngineeringModel/Views/Dialogs/ElementUsageDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/ElementUsageDialog.xaml
@@ -106,7 +106,8 @@
                         </dxg:GridControl.Columns>
                     </dxg:GridControl>
                 </lc:LayoutItem>
-
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
             <items:ExcludeOptionsLayoutGroup />
             <items:CategoryLayoutGroup />

--- a/EngineeringModel/Views/Dialogs/OptionDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/OptionDialog.xaml
@@ -31,6 +31,8 @@
                                IsChecked="{Binding Path=IsDefault, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
                                IsReadOnly="{Binding IsReadOnly}"/>
                 </lc:LayoutItem>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
             <items:CategoryLayoutGroup />
             <items:AliasLayoutGroup/>

--- a/Requirements/Views/Dialogs/RequirementDialog.xaml
+++ b/Requirements/Views/Dialogs/RequirementDialog.xaml
@@ -97,6 +97,8 @@
                 </lc:LayoutItem>
                 
                 <items:IsDeprecatedLayoutItem/>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </lc:LayoutGroup>
             <items:CategoryLayoutGroup/>
 

--- a/Requirements/Views/Dialogs/RequirementsGroupDialog.xaml
+++ b/Requirements/Views/Dialogs/RequirementsGroupDialog.xaml
@@ -34,6 +34,8 @@
                 <items:ShortNameLayoutItem/>
                 <items:NameLayoutItem/>
                 <items:OwnerLayoutItem/>
+                <items:AliasDisplayLayoutItem />
+                <items:DefinitionDisplayLayoutItem />
             </dxlc:LayoutGroup>
             <items:CategoryLayoutGroup/>
             <items:AliasLayoutGroup/>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
I have added TextArea for displaying the first element of:
- Alias (in format "alias content [alias language])
- Definition

To every dialog that displays a Thing containing Aliases and Definitions I could find.
I have also made those TextAreas into separate LayoutItems so they can be easily reused and changed later.

![image](https://user-images.githubusercontent.com/112615243/189297328-da43bd61-18d1-44a8-a4ec-901481b2d73d.png)

