### PR TITLE
Feat/gh 309 add warning to person dialog when creating a person with no password

### DIFF
--- a/CDP4SiteDirectory.Tests/Dialogs/PersonDialogViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/Dialogs/PersonDialogViewModelTestFixture.cs
@@ -168,5 +168,47 @@ namespace CDP4SiteDirectory.Tests.Dialogs
             var personDialogViewModel = new PersonDialogViewModel();
             Assert.IsNotNull(personDialogViewModel);
         }
+
+        [Test]
+        public void VerifyThatPasswordWarningIsDisplayedWhenCreatingUserWithoutPassword()
+        {
+            var transactionContext = TransactionContextResolver.ResolveContext(this.siteDir);
+            var transaction = new ThingTransaction(transactionContext, this.clone);
+
+            var vm = new PersonDialogViewModel(this.person.Clone(false), transaction, this.session.Object, true,
+                ThingDialogKind.Create, null, this.clone);
+
+            vm.PwdEditIsChecked = false;
+
+            Assert.IsTrue(vm.ShoudDisplayPasswordNotSetWarning);
+        }
+        
+        [Test]
+        public void VerifyThatPasswordWarningIsNotDisplayedWhenCreatingUserWithPassword()
+        {
+            var transactionContext = TransactionContextResolver.ResolveContext(this.siteDir);
+            var transaction = new ThingTransaction(transactionContext, this.clone);
+
+            var vm = new PersonDialogViewModel(this.person.Clone(false), transaction, this.session.Object, true,
+                ThingDialogKind.Create, null, this.clone);
+
+            vm.PwdEditIsChecked = true;
+
+            Assert.IsFalse(vm.ShoudDisplayPasswordNotSetWarning);
+        }
+
+        [Test]
+        public void VerifyThatPasswordWarningIsNotDisplayedWhenEditingUserWithoutPassword()
+        {
+            var transactionContext = TransactionContextResolver.ResolveContext(this.siteDir);
+            var transaction = new ThingTransaction(transactionContext, this.clone);
+
+            var vm = new PersonDialogViewModel(this.person.Clone(false), transaction, this.session.Object, true,
+                ThingDialogKind.Update, null, this.clone);
+
+            vm.PwdEditIsChecked = false;
+
+            Assert.IsFalse(vm.ShoudDisplayPasswordNotSetWarning);
+        }
     }
 }

--- a/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
@@ -109,7 +109,11 @@ namespace CDP4SiteDirectory.ViewModels
         public bool PwdEditIsChecked
         {
             get { return this.pwdEditIsChecked; }
-            set { this.RaiseAndSetIfChanged(ref this.pwdEditIsChecked, value); }
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.pwdEditIsChecked, value);
+                this.RaisePropertyChanged(nameof(this.ShoudDisplayPasswordNotSetWarning));
+            }
         }
 
         /// <summary>
@@ -130,7 +134,15 @@ namespace CDP4SiteDirectory.ViewModels
         /// <summary>
         /// Gets the <see cref="ICommand"/> to set the default <see cref="EmailAddress"/>
         /// </summary>
-        public ReactiveCommand<object> SetDefaultEmailAddressCommand { get; private set; } 
+        public ReactiveCommand<object> SetDefaultEmailAddressCommand { get; private set; }
+        
+        /// <summary>
+        /// Returns true if new <see cref="Person"/> nas no passwords set
+        /// </summary>
+        public bool ShoudDisplayPasswordNotSetWarning
+        {
+            get { return this.dialogKind == ThingDialogKind.Create && this.PwdEditIsChecked; }
+        }
 
         /// <summary>
         /// Gets the error message for the property with the given name.

--- a/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
@@ -146,7 +146,7 @@ namespace CDP4SiteDirectory.ViewModels
                 if ((columnName == "Password" || columnName == "PasswordConfirmation") && !this.PwdEditIsChecked)
                 {
                     var validationErrorToRemove =
-                        this.ValidationErrors.SingleOrDefault(
+                        this.ValidationErrors.FirstOrDefault(
                             x => x.PropertyName == "Password" || x.PropertyName == "PasswordConfirmation");
                     if (validationErrorToRemove != null)
                     {

--- a/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
@@ -141,7 +141,7 @@ namespace CDP4SiteDirectory.ViewModels
         /// </summary>
         public bool ShoudDisplayPasswordNotSetWarning
         {
-            get { return this.dialogKind == ThingDialogKind.Create && this.PwdEditIsChecked; }
+            get { return this.dialogKind == ThingDialogKind.Create && !this.PwdEditIsChecked; }
         }
 
         /// <summary>

--- a/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
@@ -231,7 +231,8 @@
                         <dxe:PasswordBoxEdit Name="PasswordConfirmation" Text="{Binding Path=PasswordConfirmation, Mode=TwoWay, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>
                 </lc:LayoutItem>
-                <lc:LayoutItem Label=" " Visibility="{Binding PwdEditIsChecked, Converter={StaticResource BooleanToVisibilityConverter }, ConverterParameter=Invert }">
+                <!-- Label is set to " " for positioning purposes --> 
+                <lc:LayoutItem Label=" " Visibility="{Binding ShoudDisplayPasswordNotSetWarning, Converter={StaticResource BooleanToVisibilityConverter } }">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="20" />

--- a/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:cdp4Composition="clr-namespace:CDP4Composition;assembly=CDP4Composition"
+             xmlns:cdp4Converters="clr-namespace:CDP4Composition.Converters;assembly=CDP4Composition"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
              xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
@@ -19,7 +20,7 @@
     <dx:DXWindow.Resources>
         <ResourceDictionary>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
-            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <cdp4Converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/CDP4Composition;component/CommonView/Resources/CDP4Styles.xaml"/>
                 <ResourceDictionary Source="pack://application:,,,/CDP4Composition;component/CommonView/Resources/ErrorTemplate.xaml" />
@@ -230,7 +231,16 @@
                         <dxe:PasswordBoxEdit Name="PasswordConfirmation" Text="{Binding Path=PasswordConfirmation, Mode=TwoWay, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>
                 </lc:LayoutItem>
-
+                <lc:LayoutItem Label=" " Visibility="{Binding PwdEditIsChecked, Converter={StaticResource BooleanToVisibilityConverter }, ConverterParameter=Invert }">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="20" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Image Source="{dx:DXImage Image=Warning_16x16.png}" Width="16" Height="16"/>
+                        <TextBlock Grid.Column="1">The new user will not be able to log in as long as the password is not set.</TextBlock>
+                    </Grid>
+                </lc:LayoutItem>
             </lc:LayoutGroup>
             <lc:LayoutGroup Header="E-Mails" Orientation="Vertical">
                 <lc:LayoutItem>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Warning if password is not set.
![image](https://user-images.githubusercontent.com/112615243/189846691-0b69d24f-c266-4ca3-afbd-9d7c3d072c52.png)

Also fixed a small issue that was raising exception if the password button was clicked twice.

