### PR TITLE
Persons or participants can be configured with deprecated person role or participant role

### DIFF
--- a/CDP4Composition/CDP4Composition.csproj
+++ b/CDP4Composition/CDP4Composition.csproj
@@ -374,6 +374,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="CommonView\Items\WarningLayoutItem.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="CommonView\Items\AdvancedLayoutGroup.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -684,6 +688,7 @@
   <ItemGroup>
     <None Remove="CommonView\Items\AliasDisplayLayoutItem.xaml" />
     <None Remove="CommonView\Items\DefinitionDisplayLayoutItem.xaml" />
+    <None Remove="CommonView\Items\WarningLayoutItem.xaml" />
     <None Remove="Resources\Images\cometlogo.png" />
     <None Remove="Resources\Images\cometlogo_48x48.png" />
     <None Remove="Views\CustomFilterEditorDialog.xaml" />

--- a/CDP4Composition/CommonView/Items/WarningLayoutItem.xaml
+++ b/CDP4Composition/CommonView/Items/WarningLayoutItem.xaml
@@ -1,0 +1,21 @@
+<dxlc:LayoutItem x:Class="CDP4CommonView.Items.WarningLayoutItem"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
+             xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+             xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+             mc:Ignorable="d"
+             Label=" ">
+    <dxlc:LayoutItem.Resources>
+    </dxlc:LayoutItem.Resources>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="20" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Image Source="{dx:DXImage Image=Warning_16x16.png}" Width="16" Height="16"/>
+        <TextBlock Grid.Column="1" x:Name="WarningBlock"></TextBlock>
+        </Grid>
+</dxlc:LayoutItem>

--- a/CDP4Composition/CommonView/Items/WarningLayoutItem.xaml
+++ b/CDP4Composition/CommonView/Items/WarningLayoutItem.xaml
@@ -8,6 +8,7 @@
              xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
              mc:Ignorable="d"
              Label=" ">
+    <!-- Label above is set to " " for positioning purposes -->
     <dxlc:LayoutItem.Resources>
     </dxlc:LayoutItem.Resources>
         <Grid>

--- a/CDP4Composition/CommonView/Items/WarningLayoutItem.xaml
+++ b/CDP4Composition/CommonView/Items/WarningLayoutItem.xaml
@@ -8,7 +8,7 @@
              xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
              mc:Ignorable="d"
              Label=" ">
-    <!-- Label above is set to " " for positioning purposes -->
+    <!-- Label above is set to: " " for positioning purposes -->
     <dxlc:LayoutItem.Resources>
     </dxlc:LayoutItem.Resources>
         <Grid>

--- a/CDP4Composition/CommonView/Items/WarningLayoutItem.xaml.cs
+++ b/CDP4Composition/CommonView/Items/WarningLayoutItem.xaml.cs
@@ -32,12 +32,18 @@ namespace CDP4CommonView.Items
     /// </summary>
     public partial class WarningLayoutItem : LayoutItem
     {
+        /// <summary>
+        /// Gets or sets the warning text
+        /// </summary>
         public string WarningText
         {
             get { return this.WarningBlock.Text; }
             set { this.WarningBlock.Text = value; }
         }
 
+        /// <summary>
+        /// Initializes a new instanec of the WarningLayoutItem
+        /// </summary>
         public WarningLayoutItem()
         {
             InitializeComponent();

--- a/CDP4Composition/CommonView/Items/WarningLayoutItem.xaml.cs
+++ b/CDP4Composition/CommonView/Items/WarningLayoutItem.xaml.cs
@@ -1,0 +1,46 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="WarningLayoutItem.xaml.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2022 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Omar Elebiary, Antoine Théate, Jan Oratowski, Jaimer Bernar
+//
+//    This file is part of CDP4-IME Community Edition.
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4CommonView.Items
+{
+    using DevExpress.Xpf.LayoutControl;
+
+    /// <summary>
+    /// Interaction logic for WarningLayoutItem.xaml
+    /// </summary>
+    public partial class WarningLayoutItem : LayoutItem
+    {
+        public string WarningText
+        {
+            get { return this.WarningBlock.Text; }
+            set { this.WarningBlock.Text = value; }
+        }
+
+        public WarningLayoutItem()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
@@ -91,7 +91,12 @@ namespace CDP4SiteDirectory.ViewModels
                 this.UpdateOkCanExecute();
             });
 
-            this.WhenAnyValue(vm => vm.SelectedRole).Subscribe(_ => this.UpdateOkCanExecute());
+            this.WhenAnyValue(vm => vm.SelectedRole).Subscribe(
+                _ =>
+                {
+                    this.UpdateOkCanExecute();
+                    this.RaisePropertyChanged(nameof(this.IsSelectedRoleDeprecated));
+                });
             this.WhenAnyValue(vm => vm.SelectedSelectedDomain).Subscribe(_ => this.UpdateOkCanExecute());
 
             this.WhenAnyValue(vm => vm.Domain).Subscribe(_ =>
@@ -100,6 +105,14 @@ namespace CDP4SiteDirectory.ViewModels
                 this.domainSubScription = this.Domain?.Changed.Subscribe(x => this.SetSelectedDomain());
                 this.SetSelectedDomain();
             });
+        }
+        
+        /// <summary>
+        /// Returns true if <see cref="ParticipantRole"/> is selected and is deprecated
+        /// </summary>
+        public bool IsSelectedRoleDeprecated
+        {
+            get { return this.SelectedRole != null && this.SelectedRole.IsDeprecated; }
         }
 
         /// <summary>

--- a/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
@@ -95,8 +95,8 @@ namespace CDP4SiteDirectory.ViewModels
                 _ =>
                 {
                     this.UpdateOkCanExecute();
-                    this.RaisePropertyChanged(nameof(this.IsSelectedRoleDeprecated));
                 });
+
             this.WhenAnyValue(vm => vm.SelectedSelectedDomain).Subscribe(_ => this.UpdateOkCanExecute());
 
             this.WhenAnyValue(vm => vm.Domain).Subscribe(_ =>
@@ -105,15 +105,21 @@ namespace CDP4SiteDirectory.ViewModels
                 this.domainSubScription = this.Domain?.Changed.Subscribe(x => this.SetSelectedDomain());
                 this.SetSelectedDomain();
             });
+
+            this.isSelectedRoleDeprecated =
+                this.WhenAny(x => x.SelectedRole, selectedRole => selectedRole.Value?.IsDeprecated == true)
+                    .ToProperty(this, x => x.IsSelectedRoleDeprecated, out this.isSelectedRoleDeprecated);
         }
-        
+
         /// <summary>
         /// Returns true if <see cref="ParticipantRole"/> is selected and is deprecated
         /// </summary>
         public bool IsSelectedRoleDeprecated
         {
-            get { return this.SelectedRole != null && this.SelectedRole.IsDeprecated; }
+            get { return this.isSelectedRoleDeprecated.Value; }
         }
+
+        private readonly ObservableAsPropertyHelper<bool> isSelectedRoleDeprecated;
 
         /// <summary>
         /// Initializes the lists and subscription

--- a/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
@@ -92,6 +92,19 @@ namespace CDP4SiteDirectory.ViewModels
                 this.RaisePropertyChanged("Password");
                 this.RaisePropertyChanged("PasswordConfirmation");
             });
+
+            this.WhenAnyValue(vm => vm.SelectedRole).Subscribe(x =>
+            {
+                this.RaisePropertyChanged(nameof(this.IsSelectedRoleDeprecated));
+            });
+        }
+
+        /// <summary>
+        /// Returns true if <see cref="PersonRole"/> is selected and is deprecated
+        /// </summary>
+        public bool IsSelectedRoleDeprecated
+        {
+            get { return this.SelectedRole != null && this.SelectedRole.IsDeprecated; }
         }
 
         /// <summary>

--- a/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
@@ -91,6 +91,7 @@ namespace CDP4SiteDirectory.ViewModels
             {
                 this.RaisePropertyChanged("Password");
                 this.RaisePropertyChanged("PasswordConfirmation");
+                this.RaisePropertyChanged(nameof(this.ShoudDisplayPasswordNotSetWarning));
             });
 
             this.WhenAnyValue(vm => vm.SelectedRole).Subscribe(x =>
@@ -122,11 +123,7 @@ namespace CDP4SiteDirectory.ViewModels
         public bool PwdEditIsChecked
         {
             get { return this.pwdEditIsChecked; }
-            set
-            {
-                this.RaiseAndSetIfChanged(ref this.pwdEditIsChecked, value);
-                this.RaisePropertyChanged(nameof(this.ShoudDisplayPasswordNotSetWarning));
-            }
+            set { this.RaiseAndSetIfChanged(ref this.pwdEditIsChecked, value); }
         }
 
         /// <summary>

--- a/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
@@ -20,6 +20,9 @@ namespace CDP4SiteDirectory.ViewModels
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
     using CDP4Dal;
+
+    using DevExpress.Pdf;
+
     using ReactiveUI;
 
     /// <summary>
@@ -91,13 +94,15 @@ namespace CDP4SiteDirectory.ViewModels
             {
                 this.RaisePropertyChanged("Password");
                 this.RaisePropertyChanged("PasswordConfirmation");
-                this.RaisePropertyChanged(nameof(this.ShoudDisplayPasswordNotSetWarning));
             });
 
-            this.WhenAnyValue(vm => vm.SelectedRole).Subscribe(x =>
-            {
-                this.RaisePropertyChanged(nameof(this.IsSelectedRoleDeprecated));
-            });
+            this.isSelectedRoleDeprecated =
+                this.WhenAny(x => x.SelectedRole, selectedRole => selectedRole.Value?.IsDeprecated == true)
+                    .ToProperty(this, x => x.IsSelectedRoleDeprecated, out this.isSelectedRoleDeprecated);
+
+            this.shoudDisplayPasswordNotSetWarning =
+                this.WhenAny(x => x.PwdEditIsChecked, x => !x.Value && this.dialogKind == ThingDialogKind.Create)
+                    .ToProperty(this, x => x.ShoudDisplayPasswordNotSetWarning, out this.shoudDisplayPasswordNotSetWarning);
         }
 
         /// <summary>
@@ -105,9 +110,11 @@ namespace CDP4SiteDirectory.ViewModels
         /// </summary>
         public bool IsSelectedRoleDeprecated
         {
-            get { return this.SelectedRole != null && this.SelectedRole.IsDeprecated; }
+            get { return this.isSelectedRoleDeprecated.Value; }
         }
 
+        private readonly ObservableAsPropertyHelper<bool> isSelectedRoleDeprecated;
+        
         /// <summary>
         /// Gets or sets the password confirmation value
         /// </summary>
@@ -151,8 +158,10 @@ namespace CDP4SiteDirectory.ViewModels
         /// </summary>
         public bool ShoudDisplayPasswordNotSetWarning
         {
-            get { return this.dialogKind == ThingDialogKind.Create && !this.PwdEditIsChecked; }
+            get { return this.shoudDisplayPasswordNotSetWarning.Value; }
         }
+
+        private readonly ObservableAsPropertyHelper<bool> shoudDisplayPasswordNotSetWarning;
 
         /// <summary>
         /// Gets the error message for the property with the given name.

--- a/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/PersonDialogViewModel.cs
@@ -21,8 +21,6 @@ namespace CDP4SiteDirectory.ViewModels
     using CDP4Composition.Services;
     using CDP4Dal;
 
-    using DevExpress.Pdf;
-
     using ReactiveUI;
 
     /// <summary>

--- a/CDP4SiteDirectory/Views/Dialogs/ParticipantDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/ParticipantDialog.xaml
@@ -8,14 +8,16 @@
              xmlns:lc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:navigation="clr-namespace:CDP4Composition.Navigation;assembly=CDP4Composition"
-             xmlns:converters="clr-namespace:CDP4SiteDirectory.Converters"
+             xmlns:cdp4SiteDirectoryConverters="clr-namespace:CDP4SiteDirectory.Converters"
+             xmlns:cdp4CompositionConverters="clr-namespace:CDP4Composition.Converters;assembly=CDP4Composition"
              Height="300"
              d:DesignWidth="600"
              navigation:DialogCloser.DialogResult="{Binding DialogResult}"
              mc:Ignorable="d">
     <dx:DXWindow.Resources>
         <ResourceDictionary>
-            <converters:DomainListToObjectListConverter x:Key="ReactiveDomainToObjectListConverter" />
+            <cdp4SiteDirectoryConverters:DomainListToObjectListConverter x:Key="ReactiveDomainToObjectListConverter" />
+            <cdp4CompositionConverters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         </ResourceDictionary>
     </dx:DXWindow.Resources>
     <lc:LayoutControl Margin="5"
@@ -98,7 +100,9 @@
                         </Button>
                     </Grid>
                 </lc:LayoutItem>
-
+                <items:WarningLayoutItem Visibility="{Binding Path=IsSelectedRoleDeprecated, UpdateSourceTrigger=PropertyChanged,
+                    Converter={StaticResource BooleanToVisibilityConverter }}"
+                                         WarningText="The selected role is deprecated."/>
                 <lc:LayoutItem Label="Domain of expertise" LabelPosition="Top">
                     <dxe:ListBoxEdit Name="DomainsList"
                                      MaxHeight="250"

--- a/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
@@ -234,7 +234,6 @@
                         <dxe:PasswordBoxEdit Name="PasswordConfirmation" Text="{Binding Path=PasswordConfirmation, Mode=TwoWay, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>
                 </lc:LayoutItem>
-                <!-- Label is set to " " for positioning purposes -->
                 <items:WarningLayoutItem
                     Visibility="{Binding ShoudDisplayPasswordNotSetWarning, Converter={StaticResource BooleanToVisibilityConverter }}"
                     WarningText="The new user will not be able to log in as long as the password is not set."/>

--- a/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
@@ -145,6 +145,9 @@
                     </Grid>
 
                 </lc:LayoutItem>
+                <items:WarningLayoutItem Visibility="{Binding Path=IsSelectedRoleDeprecated, UpdateSourceTrigger=PropertyChanged,
+                    Converter={StaticResource BooleanToVisibilityConverter }}"
+                                         WarningText="The selected role is deprecated."/>
                 <lc:LayoutItem Label="Default Domain:">
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -231,17 +234,10 @@
                         <dxe:PasswordBoxEdit Name="PasswordConfirmation" Text="{Binding Path=PasswordConfirmation, Mode=TwoWay, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}" />
                     </Grid>
                 </lc:LayoutItem>
-                <!-- Label is set to " " for positioning purposes --> 
-                <lc:LayoutItem Label=" " Visibility="{Binding ShoudDisplayPasswordNotSetWarning, Converter={StaticResource BooleanToVisibilityConverter } }">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="20" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <Image Source="{dx:DXImage Image=Warning_16x16.png}" Width="16" Height="16"/>
-                        <TextBlock Grid.Column="1">The new user will not be able to log in as long as the password is not set.</TextBlock>
-                    </Grid>
-                </lc:LayoutItem>
+                <!-- Label is set to " " for positioning purposes -->
+                <items:WarningLayoutItem
+                    Visibility="{Binding ShoudDisplayPasswordNotSetWarning, Converter={StaticResource BooleanToVisibilityConverter }}"
+                    WarningText="The new user will not be able to log in as long as the password is not set."/>
             </lc:LayoutGroup>
             <lc:LayoutGroup Header="E-Mails" Orientation="Vertical">
                 <lc:LayoutItem>

--- a/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
@@ -235,7 +235,8 @@
                     </Grid>
                 </lc:LayoutItem>
                 <items:WarningLayoutItem
-                    Visibility="{Binding ShoudDisplayPasswordNotSetWarning, Converter={StaticResource BooleanToVisibilityConverter }}"
+                    Visibility="{Binding ShoudDisplayPasswordNotSetWarning, UpdateSourceTrigger=PropertyChanged,
+                    Converter={StaticResource BooleanToVisibilityConverter }}"
                     WarningText="The new user will not be able to log in as long as the password is not set."/>
             </lc:LayoutGroup>
             <lc:LayoutGroup Header="E-Mails" Orientation="Vertical">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
I have re-used the warning for "password not set" and turned it into LayoutItem with property for warning text.

BTW:
I've also discovered that emojis can be used in name/short name inputs and they work just fine.

Person:
![image](https://user-images.githubusercontent.com/112615243/190175635-2b661628-b934-4c5c-a3f3-5967f3ea09ed.png)

Participant:
![image](https://user-images.githubusercontent.com/112615243/190175914-5d7d5740-b822-48a6-9b20-716152b4ddf2.png)

