### PR TITLE
Displays the About dialog when clicking on the App Logo; fixes#167

### DIFF
--- a/CDP4IME/Shell.xaml.cs
+++ b/CDP4IME/Shell.xaml.cs
@@ -33,9 +33,9 @@ namespace CDP4IME
     using CDP4Composition.Events;
     using CDP4Composition.Ribbon;
     using CDP4Dal;
-
+    using CDP4IME.Views;
     using DevExpress.Xpf.Ribbon;
-
+    using DevExpress.XtraEditors;
     using Hardcodet.Wpf.TaskbarNotification;
 
     using ReactiveUI;
@@ -68,6 +68,14 @@ namespace CDP4IME
             this.subscription = CDPMessageBus.Current.Listen<TaskbarNotificationEvent>()
                                 .ObserveOn(RxApp.MainThreadScheduler)
                                 .Subscribe(this.ShowTaskBarNotification);
+
+            this.Ribbon.MouseUp += (sender, e) => 
+            {
+                if (e.OriginalSource is RibbonApplicationButtonControl)
+                {
+                    viewModel.OpenAboutCommand.Execute(true);
+                }
+            };
         }
 
         /// <summary>

--- a/CDP4IME/Shell.xaml.cs
+++ b/CDP4IME/Shell.xaml.cs
@@ -2,7 +2,7 @@
 // <copyright file="Shell.xaml.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2021 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Simon Wood
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Simon Wood, Jaime Bernar
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
@@ -33,9 +33,7 @@ namespace CDP4IME
     using CDP4Composition.Events;
     using CDP4Composition.Ribbon;
     using CDP4Dal;
-    using CDP4IME.Views;
     using DevExpress.Xpf.Ribbon;
-    using DevExpress.XtraEditors;
     using Hardcodet.Wpf.TaskbarNotification;
 
     using ReactiveUI;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
When the COMET logo is clicked the about dialog is shown. Its done in the code behind by subscribing to an event because DevExpress.RibbonControl don't have another event, property to attach to.

<!-- Thanks for contributing to COMET-IME! -->

