### PR TITLE
[REMOVE] Remove export and help button from publication browser; fixes #1231

### DIFF
--- a/EngineeringModel/Views/PublicationBrowser/PublicationBrowser.xaml
+++ b/EngineeringModel/Views/PublicationBrowser/PublicationBrowser.xaml
@@ -151,19 +151,6 @@
                                Hint="{Binding SelectedThingClassKindString,
                                               Converter={dx:FormatStringConverter FormatString={}Refresh {0}}}" />
 
-                <dxb:BarButtonItem Command="{Binding ExportCommand}"
-                               Glyph="{dx:DXImage Image=Export_16x16.png}"
-                               Hint="{Binding SelectedThingClassKindString,
-                                              Converter={dx:FormatStringConverter FormatString={}Export {0}}}" />
-
-                <dxb:BarSplitButtonItem />
-
-                <dxb:BarButtonItem Command="{Binding HelpCommand}"
-                               Glyph="{dx:DXImage Image=Info_16x16.png}"
-                               Hint="Show Help" />
-
-                <dxb:BarSplitButtonItem />
-
             </dxb:ToolBarControl>
 
             <views:BrowserHeader Grid.Row="1" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Remove export and help button from publication browser