### PR TITLE
Feat/Grapher shows placeholder when no Top Element; fix#1260

### DIFF
--- a/CDP4Grapher.Tests/ViewModels/GrapherViewModelTestFixture.cs
+++ b/CDP4Grapher.Tests/ViewModels/GrapherViewModelTestFixture.cs
@@ -29,6 +29,7 @@ namespace CDP4Grapher.Tests.ViewModels
     using System.Linq;
     using System.Reactive.Concurrency;
     using System.Threading;
+    using System.Windows;
 
     using CDP4Common.EngineeringModelData;
     
@@ -153,6 +154,19 @@ namespace CDP4Grapher.Tests.ViewModels
             vm.SetsSelectedElementAndSelectedElementPath(vm.GraphElements.FirstOrDefault());
             Assert.IsNotNull(vm.SelectedElementModelCode);
             Assert.IsNotNull(vm.SelectedElement);
+        }
+
+        [Test]
+        public void VerifyGrapherWithNoTopElement()
+        {
+            this.Iteration.TopElement = null;
+            var vm = new GrapherViewModel(this.Option, this.Session.Object, this.thingNavigationService.Object, this.panelNavigationService.Object, this.dialogNavigationService.Object, this.pluginSettingService.Object);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(vm.GrapherVisibility, Is.EqualTo(Visibility.Collapsed));
+                Assert.That(vm.GrapherPlaceholderVisibility, Is.EqualTo(Visibility.Visible));
+            });
         }
     }
 }

--- a/CDP4Grapher/ViewModels/GrapherViewModel.cs
+++ b/CDP4Grapher/ViewModels/GrapherViewModel.cs
@@ -28,6 +28,7 @@ namespace CDP4Grapher.ViewModels
     using System;
     using System.Linq;
     using System.Reactive.Linq;
+    using System.Windows;
 
     using CDP4Common.EngineeringModelData;
     using CDP4Common.Helpers;
@@ -38,6 +39,7 @@ namespace CDP4Grapher.ViewModels
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+    using CDP4Composition.Services;
     using CDP4Composition.ViewModels;
 
     using CDP4Dal;
@@ -98,6 +100,16 @@ namespace CDP4Grapher.ViewModels
         /// Backing field for the <see cref="SelectedElementModelCode"/> Property
         /// </summary>
         private string selectedElementModelCode;
+
+        /// <summary>
+        /// Backing field for the <see cref="GrapherVisibility"/> property
+        /// </summary>
+        private Visibility grapherVisibility;
+
+        /// <summary>
+        /// Backing field for the <see cref="GrapherPlaceholderVisibility"/> property
+        /// </summary>
+        private Visibility grapherPlaceholderVisibility;
 
         /// <summary>
         /// Gets or sets the attached behavior
@@ -163,6 +175,24 @@ namespace CDP4Grapher.ViewModels
         /// Gets or sets the dock layout group target name to attach this panel to on opening
         /// </summary>
         public string TargetName { get; set; } = LayoutGroupNames.DocumentContainer;
+        
+        /// <summary>
+        /// Gets or sets the visibility of the grapher
+        /// </summary>
+        public Visibility GrapherVisibility
+        {
+            get => this.grapherVisibility;
+            set => this.RaiseAndSetIfChanged(ref this.grapherVisibility, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the visibility of the grapher's placeholder
+        /// </summary>
+        public Visibility GrapherPlaceholderVisibility
+        {
+            get => this.grapherPlaceholderVisibility;
+            set => this.RaiseAndSetIfChanged(ref this.grapherPlaceholderVisibility, value);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GrapherViewModel"/> class
@@ -248,10 +278,21 @@ namespace CDP4Grapher.ViewModels
         /// </summary>
         private void PopulateElementUsages()
         {
-            var currentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise((Iteration)this.Thing.Container);
+            var iteration = (Iteration)this.Thing.Container;
+            var currentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
 
-            var elements = new NestedElementTreeGenerator().Generate(this.option, currentDomainOfExpertise).OrderBy(e => e.ElementUsage.Count).ThenBy(e => e.Name);
-            this.GraphElements.AddRange(elements.Select(e => new GraphElementViewModel(e)));
+            if (iteration.TopElement != null)
+            {
+                var elements = new NestedElementTreeGenerator().Generate(this.option, currentDomainOfExpertise).OrderBy(e => e.ElementUsage.Count).ThenBy(e => e.Name);
+                this.GraphElements.AddRange(elements.Select(e => new GraphElementViewModel(e)));
+                this.GrapherVisibility = Visibility.Visible;
+                this.GrapherPlaceholderVisibility = Visibility.Collapsed;
+            }
+            else
+            {
+                this.GrapherVisibility = Visibility.Collapsed;
+                this.GrapherPlaceholderVisibility = Visibility.Visible;
+            }
         }
 
         /// <summary>

--- a/CDP4Grapher/ViewModels/GrapherViewModel.cs
+++ b/CDP4Grapher/ViewModels/GrapherViewModel.cs
@@ -104,12 +104,12 @@ namespace CDP4Grapher.ViewModels
         /// <summary>
         /// Backing field for the <see cref="GrapherVisibility"/> property
         /// </summary>
-        private Visibility grapherVisibility;
+        private Visibility grapherVisibility = Visibility.Visible;
 
         /// <summary>
         /// Backing field for the <see cref="GrapherPlaceholderVisibility"/> property
         /// </summary>
-        private Visibility grapherPlaceholderVisibility;
+        private Visibility grapherPlaceholderVisibility = Visibility.Collapsed;
 
         /// <summary>
         /// Gets or sets the attached behavior

--- a/CDP4Grapher/Views/Grapher.xaml
+++ b/CDP4Grapher/Views/Grapher.xaml
@@ -62,7 +62,7 @@
                                    VerticalAlignment="Center"
                                    HorizontalAlignment="Center"
                                    Visibility="{Binding GrapherPlaceholderVisibility}">
-                            The current Iteration for this option does not contain a Top Element
+                            The Graph cannot be rendered as the Iteration does not contain a Top Element
                         </TextBlock>
                     </Grid>
                 </dxdo:LayoutPanel>

--- a/CDP4Grapher/Views/Grapher.xaml
+++ b/CDP4Grapher/Views/Grapher.xaml
@@ -36,7 +36,7 @@
 
                         <TextBlock Grid.Row="1" Margin="5,10,5,10" TextAlignment="Center" Foreground="Black" FontSize="18" VerticalAlignment="Center" Background="AliceBlue" Text="{Binding SelectedElementModelCode}" HorizontalAlignment="Stretch"></TextBlock>
 
-                        <views1:GrapherDiagramControl Grid.Row="2" x:Name="diagramControl">
+                        <views1:GrapherDiagramControl Grid.Row="2" x:Name="diagramControl" Visibility="{Binding GrapherVisibility}">
                             <dxmvvm:Interaction.Behaviors>
                                 <behaviors:GrapherOrgChartBehavior 
                                     ParentMember="ParentId" 
@@ -56,6 +56,14 @@
                                 </behaviors:GrapherOrgChartBehavior>
                             </dxmvvm:Interaction.Behaviors>
                         </views1:GrapherDiagramControl>
+
+                        <TextBlock Grid.Row="2"
+                                   TextAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   HorizontalAlignment="Center"
+                                   Visibility="{Binding GrapherPlaceholderVisibility}">
+                            The current Iteration for this option does not contain a Top Element
+                        </TextBlock>
                     </Grid>
                 </dxdo:LayoutPanel>
             </dxdo:LayoutGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Two properties to control the Grapher visibility and the placeholder visibility are added. 

