### PR TITLE
All rows show the same date format. Fix #1249.

### DIFF
--- a/EngineeringModel.Tests/ViewModels/FileStoreBrowsers/FileRowViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/FileStoreBrowsers/FileRowViewModelTestFixture.cs
@@ -119,7 +119,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels.CommonFileStoreBrowser
             this.file.FileRevision.Add(this.fileRevision1);
 
             var viewModel = new FileRowViewModel(this.file, this.session.Object, domainFileStoreRowViewModel, this.fileStoreFileAndFolderHandler.Object);
-            Assert.AreEqual(this.fileRevision1.CreatedOn.ToString(CultureInfo.InvariantCulture), viewModel.CreatedOn);
+            Assert.AreEqual(this.fileRevision1.CreatedOn.ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture), viewModel.CreationDate);
             Assert.AreEqual(this.fileRevision1.Name, viewModel.Name);
             Assert.AreEqual(this.fileRevision1.Creator.Person.Name, viewModel.CreatorValue);
             Assert.IsFalse(viewModel.IsLocked);
@@ -139,7 +139,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels.CommonFileStoreBrowser
             this.revisionNumberPropertyInfo.SetValue(this.file, 11);
             CDPMessageBus.Current.SendObjectChangeEvent(this.file, EventKind.Updated);
 
-            Assert.AreEqual(this.fileRevision2.CreatedOn.ToString(CultureInfo.InvariantCulture), viewModel.CreatedOn);
+            Assert.AreEqual(this.fileRevision2.CreatedOn.ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture), viewModel.CreationDate);
             Assert.AreEqual(this.fileRevision2.Name, viewModel.Name);
             Assert.AreEqual(this.fileRevision2.Creator.Person.Name, viewModel.CreatorValue);
             this.fileStoreFileAndFolderHandler.Verify(x => x.UpdateFileRowPosition(this.file, It.IsAny<FileRevision>()), Times.Once);

--- a/EngineeringModel/ViewModels/FileStoreBrowsers/DomainFileStoreRowViewModel.cs
+++ b/EngineeringModel/ViewModels/FileStoreBrowsers/DomainFileStoreRowViewModel.cs
@@ -27,6 +27,7 @@
 namespace CDP4EngineeringModel.ViewModels
 {
     using System;
+    using System.Globalization;
     using System.Threading.Tasks;
     using System.Windows;
 
@@ -41,12 +42,19 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Dal.Events;
 
     using CDP4EngineeringModel.ViewModels.FileStoreBrowsers;
+    
+    using ReactiveUI;
 
     /// <summary>
     /// The <see cref="DomainFileStore"/> row-view-model
     /// </summary>
     public class DomainFileStoreRowViewModel : CDP4CommonView.DomainFileStoreRowViewModel, IFileStoreRow<DomainFileStore>, IDropTarget
     {
+        /// <summary>
+        /// Backing field for the <see cref="CreationDate"/> property
+        /// </summary>
+        private string creationDate;
+
         /// <summary>
         /// The <see cref="IFileStoreFileAndFolderHandler"/>
         /// </summary>
@@ -63,6 +71,15 @@ namespace CDP4EngineeringModel.ViewModels
         {
             this.fileStoreFileAndFolderHandler = new FileStoreFileAndFolderHandler<DomainFileStore>(this);
             this.UpdateProperties();
+        }
+
+        /// <summary>
+        /// Gets or sets the date of creation of the <see cref="Folder"/>
+        /// </summary>
+        public string CreationDate
+        {
+            get => this.creationDate;
+            private set => this.RaiseAndSetIfChanged(ref this.creationDate, value);
         }
 
         /// <summary>
@@ -84,6 +101,7 @@ namespace CDP4EngineeringModel.ViewModels
         private void UpdateProperties()
         {
             this.fileStoreFileAndFolderHandler.UpdateFileRows();
+            this.CreationDate = this.CreatedOn.ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture);
             this.UpdateThingStatus();
         }
 

--- a/EngineeringModel/ViewModels/FileStoreBrowsers/FileRowViewModel.cs
+++ b/EngineeringModel/ViewModels/FileStoreBrowsers/FileRowViewModel.cs
@@ -61,9 +61,9 @@ namespace CDP4EngineeringModel.ViewModels
         private string name;
 
         /// <summary>
-        /// Backing field for <see cref="CreatedOn"/>
+        /// Backing field for the <see cref="CreationDate"/> property
         /// </summary>
-        private string createdOn;
+        private string creationDate;
 
         /// <summary>
         /// Backing field for <see cref="CreatorValue"/>
@@ -114,12 +114,12 @@ namespace CDP4EngineeringModel.ViewModels
         }
 
         /// <summary>
-        /// Gets the date the current <see cref="FileRevision"/> was created
+        /// Gets or sets the date of creation of the <see cref="Folder"/>
         /// </summary>
-        public string CreatedOn
+        public string CreationDate
         {
-            get => this.createdOn;
-            private set => this.RaiseAndSetIfChanged(ref this.createdOn, value);
+            get => this.creationDate;
+            private set => this.RaiseAndSetIfChanged(ref this.creationDate, value);
         }
 
         /// <summary>
@@ -226,7 +226,7 @@ namespace CDP4EngineeringModel.ViewModels
         private void UpdateFileRevisionProperties()
         {
             this.Name = this.fileRevision.Name;
-            this.CreatedOn = this.fileRevision.CreatedOn.ToString(CultureInfo.InvariantCulture);
+            this.CreationDate = this.fileRevision.CreatedOn.ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture);
             this.CreatorValue = this.fileRevision.Creator.Person.Name;
         }
     }

--- a/EngineeringModel/Views/FileStoreBrowsers/DomainFileStoreBrowser.xaml
+++ b/EngineeringModel/Views/FileStoreBrowsers/DomainFileStoreBrowser.xaml
@@ -146,11 +146,11 @@
                     </dxg:TreeListView>
                 </dxg:TreeListControl.View>
                 <dxg:TreeListControl.Columns>
-                    <dxg:TreeListColumn FieldName="Name" />
+                    <dxg:TreeListColumn FieldName="Name"/>
                     <dxg:TreeListColumn FieldName="OwnerName" Header="Owner" />
                     <dxg:TreeListColumn FieldName="Locker" Header="Locked by" />
                     <dxg:TreeListColumn FieldName="CreatorValue" Header="Creator" />
-                    <dxg:TreeListColumn FieldName="CreatedOn" Header="Created on" />
+                    <dxg:TreeListColumn FieldName="CreationDate" Header="Created on" />
                 </dxg:TreeListControl.Columns>
 
                 <dxg:TreeListControl.InputBindings>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The field used for populating the tree has been changed from CreatedOn to CreationDate to avoid conflict with existing property in the DomainFileStoreRowViewModel. The header still shows CreatedOn value, just used for binding purposes.

