### PR TITLE
[FIX] Show error message when multiple Participants represent the same Person in a single EngineeringModelSetup

### DIFF
--- a/CDP4ShellDialogs/ViewModels/ModelSelectionEngineeringModelSetupRowViewModel.cs
+++ b/CDP4ShellDialogs/ViewModels/ModelSelectionEngineeringModelSetupRowViewModel.cs
@@ -1,25 +1,65 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ModelSelectionEngineeringModelSetupRowViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2024 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//
+//    This file is part of COMET-IME Community Edition.
+//    The COMET-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The COMET-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The COMET-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4ShellDialogs.ViewModels
 {
     using System.Linq;
+    using System.Windows;
+
     using CDP4Common.SiteDirectoryData;
 
     using CDP4CommonView;
 
     using CDP4Composition.Mvvm.Types;
+    using CDP4Composition.Services;
 
     using CDP4Dal;
+
+    using CommonServiceLocator;
+
+    using NLog;
+
+    using Splat;
+
+    using LogLevel = NLog.LogLevel;
 
     /// <summary>
     /// The Row-view-model representing a <see cref="EngineeringModelSetup"/>
     /// </summary>
-    public class ModelSelectionEngineeringModelSetupRowViewModel : CDP4CommonView.EngineeringModelSetupRowViewModel
+    public class ModelSelectionEngineeringModelSetupRowViewModel : EngineeringModelSetupRowViewModel
     {
+        /// <summary>
+        /// The NLog logger
+        /// </summary>
+        private static Logger logger = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// The INJECTED <see cref="IMessageBoxService"/>;
+        /// </summary>
+        private readonly IMessageBoxService messageBoxService = ServiceLocator.Current.GetInstance<IMessageBoxService>();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelSelectionEngineeringModelSetupRowViewModel"/> class
         /// </summary>
@@ -60,7 +100,19 @@ namespace CDP4ShellDialogs.ViewModels
         /// </param>
         private void AddIteration(IterationSetup iteration)
         {
-            var activeParticipant = this.Thing.Participant.Single(x => x.Person == this.Session.ActivePerson);
+            var participants = this.Thing.Participant.Where(x => x.Person == this.Session.ActivePerson).ToList();
+
+            if (participants.Count > 1)
+            {
+                var message = $"User '{participants.First().Person.ShortName}' is found in multiple {nameof(Participant)}s in {nameof(EngineeringModelSetup)} '{this.Thing.Name}'.";
+
+                logger.Log(LogLevel.Error, message);
+                this.messageBoxService.Show(message, $"Multiple {nameof(Participant)}s found", MessageBoxButton.OK, MessageBoxImage.Error);
+
+                return;
+            }
+
+            var activeParticipant = participants.Single();
 
             var row = new ModelSelectionIterationSetupRowViewModel(iteration, activeParticipant, this.Session);
             this.IterationSetupRowViewModels.Add(row);

--- a/CDP4ShellDialogsTestFixture/ViewModels/ModelSelectionEngineeringModelSetupRowViewModelTestFixture.cs
+++ b/CDP4ShellDialogsTestFixture/ViewModels/ModelSelectionEngineeringModelSetupRowViewModelTestFixture.cs
@@ -1,0 +1,144 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ModelSelectionEngineeringModelSetupRowViewModelTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2024 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//
+//    This file is part of COMET-IME Community Edition.
+//    The COMET-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The COMET-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The COMET-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4ShellDialogs.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reactive;
+    using System.Reactive.Concurrency;
+    using System.Reactive.Linq;
+    using System.Threading.Tasks;
+    using System.Windows;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using CDP4Composition.Services;
+
+    using CDP4Dal;
+    using CDP4Dal.DAL;
+
+    using CDP4ShellDialogs.ViewModels;
+
+    using CommonServiceLocator;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ReactiveUI;
+
+    [TestFixture]
+    public class ModelSelectionEngineeringModelSetupRowViewModelTestFixture
+    {
+        private Uri uri;
+        private Mock<ISession> session;
+        private Mock<IMessageBoxService> messageBoxService;
+        private Mock<IServiceLocator> serviceLocator;
+
+        private EngineeringModelSetup model;
+        private IterationSetup iteration;
+        private Person person;
+        private Participant participant1;
+        private Participant participant2;
+        private DomainOfExpertise domain;
+        private Assembler assembler;
+
+        private Credentials credentials;
+
+        [SetUp]
+        public void Setup()
+        {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+
+            this.uri = new Uri("http://www.rheagroup.com");
+            this.credentials = new Credentials("John", "Doe", this.uri);
+            this.session = new Mock<ISession>();
+
+            this.serviceLocator = new Mock<IServiceLocator>();
+            ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
+
+            this.messageBoxService = new Mock<IMessageBoxService>();
+            this.serviceLocator.Setup(x => x.GetInstance<IMessageBoxService>()).Returns(this.messageBoxService.Object);
+
+            var model1RDL = new ModelReferenceDataLibrary(Guid.NewGuid(), null, null) { Name = "model1RDL" };
+            this.model = new EngineeringModelSetup(Guid.NewGuid(), null, this.uri) { Name = "model" };
+            this.model.RequiredRdl.Add(model1RDL);
+            this.iteration = new IterationSetup(Guid.NewGuid(), null, this.uri);
+            this.person = new Person(Guid.NewGuid(), null, this.uri) { GivenName = "testPerson" };
+            this.domain = new DomainOfExpertise(Guid.NewGuid(), null, this.uri) { Name = "domaintest" };
+
+            this.participant1 = new Participant(Guid.NewGuid(), null, this.uri)
+            {
+                Person = this.person,
+                Domain = { this.domain }
+            };
+
+            this.participant2 = new Participant(Guid.NewGuid(), null, this.uri)
+            {
+                Person = this.person,
+                Domain = { this.domain }
+            };
+
+            this.person.DefaultDomain = this.domain;
+            this.model.Participant.Add(this.participant1);
+
+            this.model.IterationSetup.Add(this.iteration);
+
+            this.assembler = new Assembler(this.uri);
+
+            this.session.Setup(x => x.DataSourceUri).Returns("session1");
+            this.session.Setup(x => x.Assembler).Returns(this.assembler);
+            this.session.Setup(x => x.ActivePerson).Returns(this.person);
+            this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>());
+            this.session.Setup(x => x.Credentials).Returns(this.credentials);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+        }
+        
+        [Test]
+        public async Task VerifyThatIterationRowViewModelIsCreated()
+        {
+            var viewmodel = new ModelSelectionEngineeringModelSetupRowViewModel(this.model, this.session.Object);
+            Assert.That(viewmodel.IterationSetupRowViewModels.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public async Task VerifyThatErrorMessageIsShownWhenMultipleParticipantsRepresentTheSamePerson()
+        {
+            this.model.Participant.Add(this.participant2);
+            var viewmodel = new ModelSelectionEngineeringModelSetupRowViewModel(this.model, this.session.Object);
+            this.messageBoxService.Verify(x => x.Show(It.IsAny<string>(), It.IsAny<string>(), MessageBoxButton.OK, MessageBoxImage.Error), Times.Once);
+
+            Assert.That(viewmodel.IterationSetupRowViewModels.Count, Is.EqualTo(0));
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [ ] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
[FIX] Show error message when multiple Participants represent the same Person in a single EngineeringModelSetup